### PR TITLE
Disable Tracker Authenticaion Window and enable the IPFilter reset by default

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1400,8 +1400,8 @@ void TorrentHandle::handleTrackerErrorAlert(libtorrent::tracker_error_alert *p)
     qDebug("Received a tracker error for %s: %s", qPrintable(trackerUrl), qPrintable(message));
     m_trackerInfos[trackerUrl].lastMessage = message;
 
-    if (p->status_code == 401)
-        m_session->handleTorrentTrackerAuthenticationRequired(this, trackerUrl);
+    //if (p->status_code == 401)
+    //    m_session->handleTorrentTrackerAuthenticationRequired(this, trackerUrl);
 
     m_session->handleTorrentTrackerError(this, trackerUrl);
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -337,7 +337,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_ui->actionAutoHibernate->setDisabled(true);
 #endif
     m_ui->actionAutoExit->setChecked(pref->shutdownqBTWhenDownloadsComplete());
-    m_ui->actionResetIPFilter->setChecked(false);
+    m_ui->actionResetIPFilter->setChecked(true);
 
     if (!autoShutdownGroup->checkedAction())
         m_ui->actionAutoShutdownDisabled->setChecked(true);


### PR DESCRIPTION
I have found that the 'Tracker Authentication' window in qb 3.3.16 really annoying and it keeps popping out when I am running it on the computer. Several people have the same problem with me (according to [https://github.com/qbittorrent/qBittorrent/issues/8462](url)). So I made a temporary fix about this problem.

Plus, I think that the IPFilter reset on exit should be enabled by default because the Xunlei users in China don't have static IPs and banning them forever may hit some innocents.