### PR TITLE
Fix AppImage lost systray icon. #58

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ script:
 - '[ -x "/tmp/linuxdeploy-plugin-qt-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-plugin-qt-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage'
 - chmod +x '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage'
 - cd "/tmp/qbee"
+- mkdir -p "/tmp/qbee/AppDir/apprun-hooks/"
+- echo 'export XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS}:/usr/share:/usr/local/share"' > "/tmp/qbee/AppDir/apprun-hooks/xdg_data_dirs.sh"
 - UPDATE_INFORMATION="zsync|https://github.com/${TRAVIS_REPO_SLUG}/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage.zsync" OUTPUT='qBittorrent-Enhanced-Edition.AppImage' /tmp/linuxdeploy-x86_64.AppImage --appdir="/tmp/qbee/AppDir" --output=appimage --plugin qt
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 - chmod +x '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage'
 - cd "/tmp/qbee"
 - mkdir -p "/tmp/qbee/AppDir/apprun-hooks/"
-- echo 'export XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS}:/usr/share:/usr/local/share"' > "/tmp/qbee/AppDir/apprun-hooks/xdg_data_dirs.sh"
+- echo 'export XDG_DATA_DIRS="${APPDIR:-"$(dirname "${BASH_SOURCE[0]}")/.."}/usr/share:${XDG_DATA_DIRS}:/usr/share:/usr/local/share"' > "/tmp/qbee/AppDir/apprun-hooks/xdg_data_dirs.sh"
 - UPDATE_INFORMATION="zsync|https://github.com/${TRAVIS_REPO_SLUG}/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage.zsync" OUTPUT='qBittorrent-Enhanced-Edition.AppImage' /tmp/linuxdeploy-x86_64.AppImage --appdir="/tmp/qbee/AppDir" --output=appimage --plugin qt
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ will install and execute qBittorrent hopefully without any problem.
 
 ## Repository
 
+If you are using a desktop Linux distribution without any special demands, you can use AppImage from release page.
+
+Latest AppImage download: [qBittorrent-Enhanced-Edition.AppImage](https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage)
+
 ### Arch Linux (Maintainer: [c0re100](https://github.com/c0re100))
 
 [AUR](https://aur.archlinux.org/packages/qbittorrent-enhanced-git/)


### PR DESCRIPTION
解决 #58 中 AppImage 托盘图标不显示的问题。

README中添加AppImage的下载链接