### PR TITLE
Upgrade AppImage build with qt 5.12.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:mhier/libboost-latest'
-    - sourceline: 'ppa:beineri/opt-qt-5.12.3-xenial'
+    - sourceline: 'ppa:beineri/opt-qt-5.12.6-xenial'
     packages:
     - qt512base
     - qt512svg


### PR DESCRIPTION
Ubuntu的qt ppa有更新，使用目前最新的LTS版本编译AppImage