### PR TITLE
Add ppa:savoury1/backports for building AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,26 @@ addons:
     sources:
     - sourceline: 'ppa:mhier/libboost-latest'
     - sourceline: 'ppa:beineri/opt-qt-5.14.1-xenial'
+    - sourceline: 'ppa:savoury1/backports'
     packages:
+    - curl
+    - gcc
+    - g++
+    - make
+    - autoconf
+    - automake
+    - pkg-config
+    - file
+    - libgl1-mesa-dev
+    - zlib1g-dev
+    - libssl-dev
+    - libtool
     - qt514base
     - qt514svg
     - qt514tools
     - libboost1.70-dev
-    - libgl1-mesa-dev
 
 install:
-- sudo apt update && sudo apt full-upgrade -y
 - source /opt/qt514/bin/qt514-env.sh
 
 script:


### PR DESCRIPTION
找到一个ppa: savoury1/backports，可以将Ubuntu 16.04的底层编译类库进行升级。这样一来基本上编译AppImage的时候使用的都是最新版本的类库了。

关于信息中显示的编译信息如下：

```
Qt: 5.14.1
Libtorrent: 1.2.4.0
Boost: 1.70.0
OpenSSL: 1.1.1d
zlib: 1.2.11
```

我本地运行了一下，基本上没啥问题: https://github.com/abcfy2/qBittorrent-Enhanced-Edition/releases/download/v4.2.1.11-1/qBittorrent-Enhanced-Edition.AppImage