### PR TITLE
Fix #146

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:mhier/libboost-latest'
-    - sourceline: 'ppa:beineri/opt-qt-5.14.2-xenial'
     - sourceline: 'ppa:savoury1/backports'
     packages:
     - curl
@@ -18,16 +17,33 @@ addons:
     - pkg-config
     - file
     - libgl1-mesa-dev
+    - libegl1-mesa-dev
     - zlib1g-dev
     - libssl-dev
     - libtool
-    - qt514base
-    - qt514svg
-    - qt514tools
-    - libboost1.70-dev
+    - libboost1.73-dev
+    - python3-semantic-version
+    - python3-lxml
+    - python3-requests
+    - p7zip-full
+    - libfontconfig1
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-render-util0
+    - libxcb-xinerama0
+    - libxcb-xkb1
+    - libxkbcommon-x11-0
 
 install:
-- source /opt/qt514/bin/qt514-env.sh
+- curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop latest gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
+- export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
+- export QTDIR=$QT_BASE_DIR
+- export PATH=$QT_BASE_DIR/bin:$PATH
+- export LD_LIBRARY_PATH=$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
+- export PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+- export QT_QMAKE="${QT_BASE_DIR}/bin"
+- sed -i.bak 's/Enterprise/OpenSource/g;s/licheck.*//g' "${QT_BASE_DIR}/mkspecs/qconfig.pri"
 
 script:
 - mkdir -p /tmp/libtorrent-rasterbar


### PR DESCRIPTION
将qt替换为qt官方的构建版本。

合并代码之后，重新打一个新tag或者删掉4.5.13这个tag重新打一个重名的tag即可 fix #146 

另外我看你的asserts多了一个linux static build，这个构建流程是否已经稳定？如果构建过程固定的话，可以考虑一并加入到CI中自动构建。