### PR TITLE
AppImage upgrade libboost to 1.74

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ addons:
     - file
     - libgl1-mesa-dev
     - libegl1-mesa-dev
+    - libdbus-1-dev
     - zlib1g-dev
     - libssl-dev
     - libtool
-    - libboost1.73-dev
+    - libboost1.74-dev
     - python3-semantic-version
     - python3-lxml
     - python3-requests


### PR DESCRIPTION
上游已经修复了linuxdeploy构建AppImage失败的问题，所以提交PR，顺便升级下相关的构建依赖