### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,93 @@
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  release:
+    types:
+      - created
+
+jobs:
+  appimage:
+    runs-on: ubuntu-latest
+    container: "ubuntu:16.04"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: install build dependencies
+        run: |
+          apt update && apt install -y software-properties-common
+          apt-add-repository -y ppa:mhier/libboost-latest
+          apt-add-repository -y ppa:savoury1/backports
+          apt update
+          apt install -y --no-install-suggests --no-install-recommends \
+            curl \
+            gcc \
+            g++ \
+            make \
+            autoconf \
+            automake \
+            pkg-config \
+            file \
+            libgl1-mesa-dev \
+            libegl1-mesa-dev \
+            libdbus-1-dev \
+            zlib1g-dev \
+            libssl-dev \
+            libtool \
+            libboost1.74-dev \
+            python3-semantic-version \
+            python3-lxml \
+            python3-requests \
+            p7zip-full \
+            libfontconfig1 \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libxcb-xkb1 \
+            libxkbcommon-x11-0
+          mkdir -p /tmp/libtorrent-rasterbar
+          [ -f /tmp/libtorrent-rasterbar/.unpack_ok ] || \
+              curl -ksSfL https://github.com/arvidn/libtorrent/archive/RC_1_2.tar.gz | \
+              tar -zxf - -C /tmp/libtorrent-rasterbar --strip-components 1
+          touch "/tmp/libtorrent-rasterbar/.unpack_ok"
+          cd "/tmp/libtorrent-rasterbar/"
+          CXXFLAGS="-std=c++14" CPPFLAGS="-std=c++14" ./bootstrap.sh --prefix=/usr --with-boost-libdir="/usr/lib" --disable-debug --disable-dependency-tracking --disable-silent-rules --disable-maintainer-mode --with-libiconv
+          make clean
+          make -j$(nproc) V=0
+          make uninstall
+          make install
+          curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop latest gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
+          export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
+          sed -i.bak 's/Enterprise/OpenSource/g;s/licheck.*//g' "${QT_BASE_DIR}/mkspecs/qconfig.pri"
+          cd "${GITHUB_WORKSPACE}"
+      - name: build appimage
+        run: |
+          export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
+          export QTDIR=$QT_BASE_DIR
+          export PATH=$QT_BASE_DIR/bin:$PATH
+          export LD_LIBRARY_PATH=$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
+          export PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+          export QT_QMAKE="${QT_BASE_DIR}/bin"
+          ./configure --prefix=/tmp/qbee/AppDir/usr --with-boost-libdir="/usr/lib" || (cat config.log && exit 1)
+          make install -j$(nproc)
+          [ -x "/tmp/linuxdeploy-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          [ -x "/tmp/linuxdeploy-plugin-qt-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-plugin-qt-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+          chmod -v +x '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
+          cd "/tmp/qbee"
+          mkdir -p "/tmp/qbee/AppDir/apprun-hooks/"
+          echo 'export XDG_DATA_DIRS="${APPDIR:-"$(dirname "${BASH_SOURCE[0]}")/.."}/usr/share:${XDG_DATA_DIRS}:/usr/share:/usr/local/share"' > "/tmp/qbee/AppDir/apprun-hooks/xdg_data_dirs.sh"
+          APPIMAGE_EXTRACT_AND_RUN=1 OUTPUT='qBittorrent-Enhanced-Edition.AppImage' UPDATE_INFORMATION="zsync|https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage.zsync" /tmp/linuxdeploy-x86_64.AppImage --appdir="/tmp/qbee/AppDir" --output=appimage --plugin qt
+      - name: Upload Github Assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            /tmp/qbee/qBittorrent-Enhanced-Edition.AppImage
+            /tmp/qbee/qBittorrent-Enhanced-Edition.AppImage.zsync

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -64,7 +64,6 @@ jobs:
           curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop latest gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
           export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
           sed -i.bak 's/Enterprise/OpenSource/g;s/licheck.*//g' "${QT_BASE_DIR}/mkspecs/qconfig.pri"
-          cd "${GITHUB_WORKSPACE}"
       - name: build appimage
         run: |
           export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
@@ -73,6 +72,7 @@ jobs:
           export LD_LIBRARY_PATH=$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
           export PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
           export QT_QMAKE="${QT_BASE_DIR}/bin"
+          cd "${GITHUB_WORKSPACE}"
           ./configure --prefix=/tmp/qbee/AppDir/usr --with-boost-libdir="/usr/lib" || (cat config.log && exit 1)
           make install -j$(nproc)
           [ -x "/tmp/linuxdeploy-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
@@ -84,10 +84,80 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN=1 OUTPUT='qBittorrent-Enhanced-Edition.AppImage' UPDATE_INFORMATION="zsync|https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage.zsync" /tmp/linuxdeploy-x86_64.AppImage --appdir="/tmp/qbee/AppDir" --output=appimage --plugin qt
       - name: Upload Github Assets
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: svenstaro/upload-release-action@v2
         with:
-          files: |
-            /tmp/qbee/qBittorrent-Enhanced-Edition.AppImage
-            /tmp/qbee/qBittorrent-Enhanced-Edition.AppImage.zsync
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "/tmp/qbee/qBittorrent-Enhanced-Edition.AppImage*"
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+  # Inspired by https://github.com/userdocs/qbittorrent-nox-static/blob/master/qbittorrent-nox-static-musl.sh
+  nox-static:
+    runs-on: ubuntu-latest
+    container: "alpine:edge"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: install build dependencies
+        run: |
+          apk add g++ \
+            git \
+            make \
+            autoconf \
+            automake \
+            libtool \
+            boost-static \
+            boost-dev \
+            openssl-dev \
+            openssl-libs-static \
+            tar \
+            jq \
+            zlib-dev \
+            zlib-static \
+            icu-dev \
+            icu-static
+      - name: build nox-static
+        run: |
+          export CXXFLAGS="-std=c++14"
+          qt_tag="$(wget -qO- https://api.github.com/repos/qt/qtbase/tags | jq -r '.[0].name')"
+          [ -d /tmp/qtbase/ ] || \
+            git clone --branch "${qt_tag}" --recursive -j$(nproc) --depth 1 https://github.com/qt/qtbase.git "/tmp/qtbase"
+          cd /tmp/qtbase
+          ./configure --prefix=/usr/local/ -silent --openssl-linked -static -opensource -confirm-license -release -c++std c++14 -no-shared -no-opengl -no-dbus -no-widgets -no-gui -no-compile-examples QMAKE_LFLAGS="$LDFLAGS"
+          make -j$(nproc)
+          make install
+          [ -d /tmp/qttools ] || \
+            git clone --branch "${qt_tag}" --recursive -j$(nproc) --depth 1 https://github.com/qt/qttools.git "/tmp/qttools"
+          cd /tmp/qttools
+          qmake -set prefix "/usr/local/"
+          qmake
+          make -j$(nproc)
+          make install
+          mkdir -p /tmp/libtorrent-rasterbar
+          [ -f /tmp/libtorrent-rasterbar/.unpack_ok ] || \
+            wget -qO- https://github.com/arvidn/libtorrent/archive/RC_1_2.tar.gz | \
+            tar -zxf - -C /tmp/libtorrent-rasterbar --strip-components 1
+          touch "/tmp/libtorrent-rasterbar/.unpack_ok"
+          cd /tmp/libtorrent-rasterbar
+          ./bootstrap.sh
+          make -j$(nproc)
+          make install
+          cd "${GITHUB_WORKSPACE}"
+          ./configure --disable-gui LDFLAGS="--static"
+          make -j$(nproc)
+          make install
+          strip /usr/local/bin/qbittorrent-nox
+      - name: upx compressing
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          apk add upx
+          upx --best -o /tmp/qbittorrent-nox_linux_x64_static_build /usr/local/bin/qbittorrent-nox
+      - name: Upload Github Assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /tmp/qbittorrent-nox_linux_x64_static_build
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
改用github action做CI，以后应该不需要再改动.travis-ci了，防止跟上游冲突。

可以考虑直接停用旧的travis-ci。直接在travis-ci.com网站设置中，取消qBittorrent-Enhanced_Edition的持续集成即可，或者干脆删掉.travis-ci.yml文件也行。

另外可以整理下其他操作系统的构建脚本与步骤，考虑如何自动化，我看github action支持windows和Macos做构建环境，理论上可以在CI同时构建三个平台的二进制包，可以考虑下，整理下相关的脚本，以后加到github action就可以了