### PR TITLE
Add cross compile for some other platforms release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -104,6 +104,7 @@ jobs:
           apk add g++ \
             git \
             make \
+            file \
             autoconf \
             automake \
             libtool \
@@ -114,9 +115,7 @@ jobs:
             tar \
             jq \
             zlib-dev \
-            zlib-static \
-            icu-dev \
-            icu-static
+            zlib-static
       - name: build nox-static
         run: |
           export CXXFLAGS="-std=c++14"
@@ -124,7 +123,10 @@ jobs:
           [ -d /tmp/qtbase/ ] || \
             git clone --branch "${qt_tag}" --recursive -j$(nproc) --depth 1 https://github.com/qt/qtbase.git "/tmp/qtbase"
           cd /tmp/qtbase
-          ./configure --prefix=/usr/local/ -silent --openssl-linked -static -opensource -confirm-license -release -c++std c++14 -no-shared -no-opengl -no-dbus -no-widgets -no-gui -no-compile-examples QMAKE_LFLAGS="$LDFLAGS"
+          ./configure --prefix=/usr/local/ -optimize-size -silent --openssl-linked \
+            -static -opensource -confirm-license -release -c++std c++14 -no-opengl \
+            -no-dbus -no-widgets -no-gui -no-compile-examples -ltcg -make libs -no-pch \
+            -nomake tests -nomake examples -no-xcb -silent -no-feature-testlib -no-feature-sql
           make -j$(nproc)
           make install
           [ -d /tmp/qttools ] || \
@@ -148,11 +150,19 @@ jobs:
           make -j$(nproc)
           make install
           strip /usr/local/bin/qbittorrent-nox
+          # Just check if artifact is working
+          du -h /usr/local/bin/qbittorrent-nox
+          /usr/local/bin/qbittorrent-nox --help
+          /usr/local/bin/qbittorrent-nox --version
       - name: upx compressing
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           apk add upx
           upx --best -o /tmp/qbittorrent-nox_linux_x64_static_build /usr/local/bin/qbittorrent-nox
+          # Check artifact is working after upx compressing
+          du -h /tmp/qbittorrent-nox_linux_x64_static_build
+          /tmp/qbittorrent-nox_linux_x64_static_build --help
+          /tmp/qbittorrent-nox_linux_x64_static_build --version
       - name: Upload Github Assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -146,28 +146,149 @@ jobs:
           make -j$(nproc)
           make install
           cd "${GITHUB_WORKSPACE}"
-          ./configure --disable-gui LDFLAGS="--static"
+          ./configure --disable-gui LDFLAGS="-s -static --static"
           make -j$(nproc)
           make install
-          strip /usr/local/bin/qbittorrent-nox
-          # Just check if artifact is working
-          du -h /usr/local/bin/qbittorrent-nox
-          /usr/local/bin/qbittorrent-nox --help
-          /usr/local/bin/qbittorrent-nox --version
-      - name: upx compressing
+      - name: upx compressing and zip archiving
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          apk add upx
-          upx --best -o /tmp/qbittorrent-nox_linux_x64_static_build /usr/local/bin/qbittorrent-nox
-          # Check artifact is working after upx compressing
-          du -h /tmp/qbittorrent-nox_linux_x64_static_build
-          /tmp/qbittorrent-nox_linux_x64_static_build --help
-          /tmp/qbittorrent-nox_linux_x64_static_build --version
+          apk add upx zip
+          upx --best -o /tmp/qbittorrent-nox /usr/local/bin/qbittorrent-nox
+          zip -j9v /tmp/qbittorrent-nox_linux_x64_static.zip /tmp/qbittorrent-nox
       - name: Upload Github Assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /tmp/qbittorrent-nox_linux_x64_static_build
+          file: /tmp/qbittorrent-nox_linux_x64_static.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+  # cross compile for some other platforms, like arm, mips, etc.
+  cross-compile:
+    runs-on: ubuntu-latest
+    container: "alpine:latest"
+    strategy:
+      matrix:
+        include:
+          # cross toolchain downloads from: https://musl.cc/
+          # you need to find the name ${cross_host}-cross.tgz
+          # openssl_compiler choose from openssl source directory `./Configure LIST`
+          # qt_device choose from https://github.com/qt/qtbase/tree/dev/mkspecs/devices
+          - cross_host: arm-linux-musleabi
+            openssl_compiler: linux-armv4
+            qt_device: linux-arm-generic-g++
+          - cross_host: aarch64-linux-musl
+            openssl_compiler: linux-aarch64
+            qt_device: linux-arm-generic-g++
+          - cross_host: mips-linux-musl
+            openssl_compiler: linux-mips32
+            qt_device: linux-generic-g++
+          - cross_host: mipsel-linux-musl
+            openssl_compiler: linux-mips32
+            qt_device: linux-generic-g++
+          - cross_host: mips64-linux-musl
+            openssl_compiler: linux64-mips64
+            qt_device: linux-generic-g++
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: install build dependencies
+        run: |
+          apk add gcc \
+            g++ \
+            git \
+            make \
+            file \
+            perl \
+            autoconf \
+            automake \
+            libtool \
+            tar \
+            jq \
+            pkgconfig \
+            linux-headers
+      - name: cross compile nox-static
+        env:
+          CROSS_HOST: "${{ matrix.cross_host }}"
+          OPENSSL_COMPILER: "${{ matrix.openssl_compiler }}"
+          QT_DEVICE: "${{matrix.qt_device}}"
+          LIBTORRENT_BRANCH: "RC_1_2"
+        run: |
+          mkdir -p /cross_root /usr/src/zlib /usr/src/openssl /usr/src/boost /usr/src/libtorrent
+          export PATH="/cross_root/bin:${PATH}"
+          export CROSS_PREFIX="/cross_root/${CROSS_HOST}"
+          export PKG_CONFIG_PATH="${CROSS_PREFIX}/opt/qt/lib/pkgconfig:${CROSS_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+          wget -qO- "https://musl.cc/${CROSS_HOST}-cross.tgz" | tar -zxf - --strip-components=1 -C /cross_root/
+          zlib_latest_url="$(wget -qO- https://api.github.com/repos/madler/zlib/tags | jq -r '.[0].tarball_url')"
+          wget -qO- "${zlib_latest_url}" | tar -zxf - --strip-components=1 -C /usr/src/zlib
+          cd /usr/src/zlib
+          CHOST="${CROSS_HOST}" ./configure --prefix="${CROSS_PREFIX}" --static
+          make -j$(nproc)
+          make install
+          openssl_file_name="$(wget -qO- https://github.com/openssl/openssl/releases | grep -o 'OpenSSL_1_1.*.tar.gz' | head -1)"
+          wget -qO- "https://github.com/openssl/openssl/archive/${openssl_file_name}" | tar -zxf - --strip-components=1 -C /usr/src/openssl
+          cd /usr/src/openssl
+          ./Configure -static --cross-compile-prefix="${CROSS_HOST}-" --prefix="${CROSS_PREFIX}" "${OPENSSL_COMPILER}"
+          make -j$(nproc)
+          make install_sw
+          boost_latest_url="$(wget -qO- https://www.boost.org/users/download/ | grep -o 'http[^"]*.tar.bz2')"
+          wget -qO- "${boost_latest_url}" | tar -jxf - --strip-components=1 -C /usr/src/boost
+          cd /usr/src/boost
+          ./bootstrap.sh
+          sed -i "s/using gcc.*/using gcc : cross : ${CROSS_HOST}-g++ ;/" project-config.jam
+          ./b2 install --prefix="${CROSS_PREFIX}" --with-system toolset=gcc-cross variant=release link=static runtime-link=static
+          qt_tag="$(wget -qO- https://api.github.com/repos/qt/qtbase/tags | jq -r '.[0].name')"
+          [ -d /usr/src/qtbase/ ] || \
+            git clone --branch "${qt_tag}" --recursive -j$(nproc) --depth 1 https://github.com/qt/qtbase.git "/usr/src/qtbase"
+          cd /usr/src/qtbase
+          # Remove some options no support by this toolchain
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-fno-fat-lto-objects//g'
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-fuse-linker-plugin//g'
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-mfloat-abi=softfp//g'
+          ./configure --prefix=/opt/qt/ -optimize-size -silent --openssl-linked \
+            -static -opensource -confirm-license -release -c++std c++14 -no-opengl \
+            -no-dbus -no-widgets -no-gui -no-compile-examples -ltcg -make libs -no-pch \
+            -nomake tests -nomake examples -no-xcb -no-feature-testlib -no-feature-sql \
+            -hostprefix /cross_root -device "${QT_DEVICE}" -device-option CROSS_COMPILE="${CROSS_HOST}-" \
+            -sysroot "${CROSS_PREFIX}"
+          make -j$(nproc)
+          make install
+          [ -d /usr/src/qttools ] || \
+            git clone --branch "${qt_tag}" --recursive -j$(nproc) --depth 1 https://github.com/qt/qttools.git "/usr/src/qttools"
+          cd /usr/src/qttools
+          qmake -set prefix "/cross_root"
+          qmake
+          # Remove some options no support by this toolchain
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-fno-fat-lto-objects//g'
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-fuse-linker-plugin//g'
+          find -name '*.conf' -print0 | xargs -0 -r sed -i 's/-mfloat-abi=softfp//g'
+          make -j$(nproc)
+          make install
+          cd /cross_root/bin
+          ln -sf lrelease "lrelease-qt${qt_tag:1:1}"
+          wget -qO- "https://github.com/arvidn/libtorrent/archive/${LIBTORRENT_BRANCH}.tar.gz" | tar -zxf - --strip-components=1 -C /usr/src/libtorrent
+          cd /usr/src/libtorrent
+          ./bootstrap.sh CXXFLAGS='-std=c++14' --host="${CROSS_HOST}" --prefix="${CROSS_PREFIX}" --enable-static --disable-shared --with-boost="${CROSS_PREFIX}"
+          make -j$(nproc)
+          make install
+          cd "${GITHUB_WORKSPACE}"
+          ./configure --host="${CROSS_HOST}" --prefix="${CROSS_PREFIX}" --disable-gui --with-boost="${CROSS_PREFIX}" CXXFLAGS='-std=c++14' LDFLAGS='-s -static --static'
+          make -j$(nproc)
+          make install
+          cp -fv "${CROSS_PREFIX}/bin/qbittorrent-nox" /tmp/
+      - name: zip archiving
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          CROSS_HOST: "${{ matrix.cross_host }}"
+        run: |
+          apk add zip
+          zip -j9v /tmp/qbittorrent-nox_${CROSS_HOST}_static.zip /tmp/qbittorrent-nox
+      - name: Upload Github Assets
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /tmp/qbittorrent-nox_${{ matrix.cross_host }}_static.zip
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
编译去掉了ICU依赖，减少了nox-static的体积。

加入了交叉编译的构建，目前可以构建出arm/aarch64/mips/mipsel/mips64架构的程序（arm和aarch64手头有设备，可以测试通过，mips系列手头暂时没有真机，期待有人能帮忙测试）

为防止某些情况下可执行程序会被浏览器拦截或者被某些安全查杀所拦截，release发布采用打包zip的方案，既可以压缩体积，也可以保住权限，基本上不会被拦截