### PR TITLE
reimplemented "ban bad peers" feature

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -129,7 +129,7 @@ jobs:
           ./configure --prefix=/usr/local/ -optimize-size -silent --openssl-linked \
             -static -opensource -confirm-license -release -c++std c++14 -no-opengl \
             -no-dbus -no-widgets -no-gui -no-compile-examples -ltcg -make libs -no-pch \
-            -nomake tests -nomake examples -no-xcb -silent -no-feature-testlib -no-feature-sql
+            -nomake tests -nomake examples -no-xcb -silent -no-feature-testlib
           make -j$(nproc)
           make install
           [ -d /tmp/qttools ] || \
@@ -254,7 +254,7 @@ jobs:
           ./configure --prefix=/opt/qt/ -optimize-size -silent --openssl-linked \
             -static -opensource -confirm-license -release -c++std c++14 -no-opengl \
             -no-dbus -no-widgets -no-gui -no-compile-examples -ltcg -make libs -no-pch \
-            -nomake tests -nomake examples -no-xcb -no-feature-testlib -no-feature-sql \
+            -nomake tests -nomake examples -no-xcb -no-feature-testlib \
             -hostprefix /cross_root -device "${QT_DEVICE}" -device-option CROSS_COMPILE="${CROSS_HOST}-" \
             -sysroot "${CROSS_PREFIX}"
           make -j$(nproc)

--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -9,43 +9,6 @@
 #include "peer_filter_plugin.hpp"
 #include "peer_logger.hpp"
 
-/*
-// bad peer
-bool isBadPeer(const lt::peer_info& info)
-{
-  QString pid = QString::fromStdString(info.pid.to_string().substr(0, 8));
-  QString client = QString::fromStdString(info.client);
-  QRegExp IDFilter("-(XL|SD|XF|QD|BN|DL)(\\d+)-");
-  QRegExp UAFilter(R"((\d+.\d+.\d+.\d+|cacao_torrent))");
-  return IDFilter.exactMatch(pid) || UAFilter.exactMatch(client);
-}
-
-// Unknown Peer
-bool isUnknownPeer(const lt::peer_info& info)
-{
-  QString client = QString::fromStdString(info.client);
-  QString country = Net::GeoIPManager::instance()->lookup({info.ip.data(), info.ip.port()});
-  return client.contains("Unknown") && country == "CN";
-}
-
-// Offline Downloader
-bool isOfflineDownloader(const lt::peer_info& info)
-{
-  unsigned short port = info.ip.port();
-  QString country = Net::GeoIPManager::instance()->lookup({info.ip.data(), info.ip.port()});
-  QString client = QString::fromStdString(info.client);
-  return port >= 65000 && country == "CN" && client.contains("Transmission");
-}
-
-// BitTorrent Media Player Peer
-bool isBitTorrentMediaPlayer(const lt::peer_info& info)
-{
-  QString pid = QString::fromStdString(info.pid.to_string().substr(0, 8));
-  QRegExp PlayerFilter("-(UW\\w{4})-");
-  return PlayerFilter.exactMatch(pid);
-}
-*/
-
 // bad peer filter
 bool is_bad_peer(const lt::peer_info& info)
 {

--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <regex>
+
+#include <libtorrent/torrent_info.hpp>
+
+#include "base/net/geoipmanager.h"
+
+#include "peer_filter_plugin.hpp"
+#include "peer_logger.hpp"
+
+/*
+// bad peer
+bool isBadPeer(const lt::peer_info& info)
+{
+  QString pid = QString::fromStdString(info.pid.to_string().substr(0, 8));
+  QString client = QString::fromStdString(info.client);
+  QRegExp IDFilter("-(XL|SD|XF|QD|BN|DL)(\\d+)-");
+  QRegExp UAFilter(R"((\d+.\d+.\d+.\d+|cacao_torrent))");
+  return IDFilter.exactMatch(pid) || UAFilter.exactMatch(client);
+}
+
+// Unknown Peer
+bool isUnknownPeer(const lt::peer_info& info)
+{
+  QString client = QString::fromStdString(info.client);
+  QString country = Net::GeoIPManager::instance()->lookup({info.ip.data(), info.ip.port()});
+  return client.contains("Unknown") && country == "CN";
+}
+
+// Offline Downloader
+bool isOfflineDownloader(const lt::peer_info& info)
+{
+  unsigned short port = info.ip.port();
+  QString country = Net::GeoIPManager::instance()->lookup({info.ip.data(), info.ip.port()});
+  QString client = QString::fromStdString(info.client);
+  return port >= 65000 && country == "CN" && client.contains("Transmission");
+}
+
+// BitTorrent Media Player Peer
+bool isBitTorrentMediaPlayer(const lt::peer_info& info)
+{
+  QString pid = QString::fromStdString(info.pid.to_string().substr(0, 8));
+  QRegExp PlayerFilter("-(UW\\w{4})-");
+  return PlayerFilter.exactMatch(pid);
+}
+*/
+
+// bad peer filter
+bool is_bad_peer(const lt::peer_info& info)
+{
+  std::string pid = info.pid.to_string().substr(0, 8);
+  std::regex id_filter("-(XL|SD|XF|QD|BN|DL)(\\d+)-");
+  std::regex ua_filter(R"((\d+.\d+.\d+.\d+|cacao_torrent))");
+  return std::regex_match(pid, id_filter) || std::regex_match(info.client, ua_filter);
+}
+
+// Unknown Peer filter
+bool is_unknown_peer(const lt::peer_info& info)
+{
+  QString country = Net::GeoIPManager::instance()->lookup(QHostAddress(info.ip.data()));
+  return info.client.find("Unknown") != std::string::npos && country == QLatin1String("CN");
+}
+
+// Offline Downloader filter
+bool is_offline_downloader(const lt::peer_info& info)
+{
+  unsigned short port = info.ip.port();
+  QString country = Net::GeoIPManager::instance()->lookup(QHostAddress(info.ip.data()));
+  return port >= 65000 && country == QLatin1String("CN") && info.client.find("Transmission") != std::string::npos;
+}
+
+// BitTorrent Media Player Peer filter
+bool is_bittorrent_media_player(const lt::peer_info& info)
+{
+  std::string pid = info.pid.to_string().substr(0, 8);
+  std::regex player_filter("-(UW\\w{4})-");
+  return !!std::regex_match(pid, player_filter);
+}
+
+
+// drop connection action
+void drop_connection(lt::peer_connection_handle ph)
+{
+  ph.disconnect(boost::asio::error::connection_refused, lt::operation_t::bittorrent, 0);
+}
+
+
+class peer_logger_singleton
+{
+public:
+  static peer_logger_singleton& instance()
+  {
+    static peer_logger_singleton logger;
+    return logger;
+  }
+
+  void log_peer(const lt::peer_info& info, const std::string& tag)
+  {
+    m_logger.log_peer(info, tag);
+  }
+
+protected:
+  peer_logger_singleton()
+    : m_logger(db_connection::instance().connection(), QStringLiteral("banned_peers"))
+  {}
+
+private:
+  peer_logger m_logger;
+};
+
+
+template<typename F>
+auto wrap_filter(F filter, const lt::torrent_handle& th, const std::string& tag)
+{
+  return [=](const lt::peer_info& info, bool) {
+    // ignore private torrents
+    if (th.torrent_file() && th.torrent_file()->priv())
+      return false;
+
+    bool matched = filter(info);
+    if (matched)
+      peer_logger_singleton::instance().log_peer(info, tag);
+    return matched;
+  };
+}
+
+
+// plugins factory functions
+
+std::shared_ptr<lt::torrent_plugin> create_drop_bad_peers_plugin(lt::torrent_handle const& th, void* d)
+{
+  return peer_action_plugin_creator(wrap_filter(is_bad_peer, th, "bad peer"), drop_connection)(th, d);
+}
+
+std::shared_ptr<lt::torrent_plugin> create_drop_unknown_peers_plugin(lt::torrent_handle const& th, void* d)
+{
+  return peer_action_plugin_creator(wrap_filter(is_unknown_peer, th, "unknown peer"), drop_connection)(th, d);
+}
+
+std::shared_ptr<lt::torrent_plugin> create_drop_offline_downloader_plugin(lt::torrent_handle const& th, void* d)
+{
+  return peer_action_plugin_creator(wrap_filter(is_offline_downloader, th, "offline downloader"), drop_connection)(th, d);
+}
+
+std::shared_ptr<lt::torrent_plugin> create_drop_bittorrent_media_player_plugin(lt::torrent_handle const& th, void* d)
+{
+  return peer_action_plugin_creator(wrap_filter(is_bittorrent_media_player, th, "bittorrent media player"), drop_connection)(th, d);
+}

--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -45,7 +45,7 @@ bool is_bittorrent_media_player(const lt::peer_info& info)
 // drop connection action
 void drop_connection(lt::peer_connection_handle ph)
 {
-  ph.disconnect(boost::asio::error::connection_refused, lt::operation_t::bittorrent, 0);
+  ph.disconnect(boost::asio::error::connection_refused, lt::operation_t::bittorrent, lt::disconnect_severity_t{0});
 }
 
 

--- a/src/base/bittorrent/peer_filter_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_plugin.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <libtorrent/extensions.hpp>
+#include <libtorrent/peer_connection_handle.hpp>
+
+using filter_function = std::function<bool(const lt::peer_info&, bool)>;
+using action_function = std::function<void(lt::peer_connection_handle)>;
+
+class peer_filter_plugin final : public lt::peer_plugin
+{
+public:
+  peer_filter_plugin(lt::peer_connection_handle p, filter_function filter, action_function action)
+    : m_peer_connection(p)
+    , m_filter(std::move(filter))
+    , m_action(std::move(action))
+  {}
+
+  void add_handshake(lt::entry& e) override
+  {
+    handle_peer(true);
+    peer_plugin::add_handshake(e);
+  }
+
+  bool on_handshake(lt::span<char const> d) override
+  {
+    handle_peer(true);
+    return peer_plugin::on_handshake(d);
+  }
+
+  bool on_extension_handshake(lt::bdecode_node const& d) override
+  {
+    handle_peer(true);
+    return peer_plugin::on_extension_handshake(d);
+  }
+
+  bool on_interested() override
+  {
+    handle_peer();
+    return peer_plugin::on_interested();
+  }
+
+  bool on_have(lt::piece_index_t p) override
+  {
+    handle_peer();
+    return peer_plugin::on_have(p);
+  }
+
+  bool on_bitfield(lt::bitfield const& bitfield) override
+  {
+    handle_peer();
+    return peer_plugin::on_bitfield(bitfield);
+  }
+
+  bool on_have_all() override
+  {
+    handle_peer();
+    return peer_plugin::on_have_all();
+  }
+
+  bool on_request(lt::peer_request const& r) override
+  {
+    handle_peer();
+    return peer_plugin::on_request(r);
+  }
+
+protected:
+  void handle_peer(bool handshake = false)
+  {
+    lt::peer_info info;
+    m_peer_connection.get_peer_info(info);
+
+    if (m_filter(info, handshake))
+      m_action(m_peer_connection);
+  }
+
+private:
+  lt::peer_connection_handle m_peer_connection;
+
+  filter_function m_filter;
+  action_function m_action;
+};
+
+
+class peer_action_plugin : public lt::torrent_plugin
+{
+public:
+  peer_action_plugin(filter_function filter, action_function action)
+    : m_filter(std::move(filter))
+    , m_action(std::move(action))
+  {}
+
+  std::shared_ptr<lt::peer_plugin> new_connection(lt::peer_connection_handle const& p) override
+  {
+    return std::make_shared<peer_filter_plugin>(p, m_filter, m_action);
+  }
+
+private:
+  filter_function m_filter;
+  action_function m_action;
+};
+
+
+class peer_action_plugin_creator
+{
+public:
+  peer_action_plugin_creator(filter_function filter, action_function action)
+    : m_filter(std::move(filter))
+    , m_action(std::move(action))
+  {}
+
+  std::shared_ptr<lt::torrent_plugin> operator()(lt::torrent_handle const&, void*)
+  {
+    return std::make_shared<peer_action_plugin>(m_filter, m_action);
+  }
+
+private:
+  filter_function m_filter;
+  action_function m_action;
+};

--- a/src/base/bittorrent/peer_logger.hpp
+++ b/src/base/bittorrent/peer_logger.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <libtorrent/peer_info.hpp>
+
+#include <QSqlDatabase>
+#include <QSqlField>
+#include <QSqlRecord>
+#include <QSqlTableModel>
+#include <QSqlQuery>
+
+
+class db_connection
+{
+public:
+  static db_connection& instance()
+  {
+    static db_connection c;
+    return c;
+  }
+
+  void init(const QString& db_path)
+  {
+    m_db.setDatabaseName(db_path);
+    m_db.open();
+  }
+
+  QSqlDatabase connection() const
+  {
+    return m_db;
+  }
+
+protected:
+  db_connection()
+    : m_db(QSqlDatabase::addDatabase("QSQLITE"))
+  {}
+
+  ~db_connection()
+  {
+    m_db.close();
+  }
+
+private:
+  QSqlDatabase m_db;
+};
+
+
+class peer_logger
+{
+public:
+  explicit peer_logger(QSqlDatabase db, QString table)
+    : m_model(nullptr, db)
+  {
+    if (!db.tables().contains(table)) {
+      db.exec(QString(
+                "CREATE TABLE '%1' ("
+                "    'id'      INTEGER NOT NULL UNIQUE,"
+                "    'ip'      TEXT NOT NULL UNIQUE,"
+                "    'client'  TEXT,"
+                "    'pid'     TEXT,"
+                "    'tag'     TEXT,"
+                "    PRIMARY KEY('id' AUTOINCREMENT)"
+                ");").arg(table));
+      db.commit();
+    }
+
+    m_model.setTable(table);
+  }
+
+  bool log_peer(const lt::peer_info& info, const std::string& tag = {})
+  {
+    QSqlRecord r;
+    r.append(QSqlField(QStringLiteral("ip"), QVariant::String));
+    r.append(QSqlField(QStringLiteral("client"), QVariant::String));
+    r.append(QSqlField(QStringLiteral("pid"), QVariant::String));
+    r.append(QSqlField(QStringLiteral("tag"), QVariant::String));
+
+    r.setValue(QStringLiteral("ip"), QString::fromStdString(info.ip.address().to_string()));
+    r.setValue(QStringLiteral("client"), QString::fromStdString(info.client));
+    r.setValue(QStringLiteral("pid"), QString::fromStdString(info.pid.to_string().substr(0, 8)));
+    r.setValue(QStringLiteral("tag"), QString::fromStdString(tag));
+
+    return m_model.insertRecord(-1, r);
+  }
+
+private:
+  QSqlTableModel m_model;
+};

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -175,11 +175,6 @@ PeerAddress PeerInfo::address() const
     //    , m_nativeInfo.ip.port()};
 }
 
-int PeerInfo::port() const
-{
-    return m_nativeInfo.ip.port();
-}
-
 QString PeerInfo::client() const
 {
     return QString::fromStdString(m_nativeInfo.client);
@@ -188,11 +183,6 @@ QString PeerInfo::client() const
 QString PeerInfo::peerId() const
 {
     return QString::fromStdString(m_nativeInfo.pid.to_string());
-}
-
-QString PeerInfo::peerIdToClient() const
-{
-    return QString::fromStdString(lt::identify_client(m_nativeInfo.pid));
 }
 
 qreal PeerInfo::progress() const

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -30,7 +30,6 @@
 #define BITTORRENT_PEERINFO_H
 
 #include <libtorrent/peer_info.hpp>
-#include <libtorrent/identify_client.hpp>
 
 #include <QCoreApplication>
 
@@ -79,10 +78,8 @@ namespace BitTorrent
         bool isPlaintextEncrypted() const;
 
         PeerAddress address() const;
-        int port() const;
         QString client() const;
         QString peerId() const;
-        QString peerIdToClient() const;
         qreal progress() const;
         int payloadUpSpeed() const;
         int payloadDownSpeed() const;

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -56,7 +56,6 @@
 #include <libtorrent/session_status.hpp>
 #include <libtorrent/torrent_info.hpp>
 
-#include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -71,8 +70,6 @@
 #include <QUuid>
 
 #include "base/algorithm.h"
-#include "base/bittorrent/peerinfo.h"
-#include "base/bittorrent/peeraddress.h"
 #include "base/exceptions.h"
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -40,9 +40,7 @@
 
 #include <QHash>
 #include <QPointer>
-#include <QQueue>
 #include <QSet>
-#include <QTimer>
 #include <QVector>
 
 #include "base/settingvalue.h"
@@ -506,19 +504,8 @@ namespace BitTorrent
         void updatePublicTracker();
 
         // Enhanced Function
-        bool m_isActive = false;
-        QQueue<QString> q_bannedIPs;
-        QQueue<int64_t> q_unbanTime;
         CachedSettingValue<QString> m_publicTrackers;
-        QTimer *m_unbanTimer;
-        QTimer *m_banTimer;
         QTimer *m_updateTimer;
-
-        void autoBanBadClient();
-        bool checkAccessFlags(const QString &ip);
-        void insertQueue(QString ip);
-        void removeBlockedIP(const QString &ip);
-        void tempBlockIP(const QString &ip);
 
     signals:
         void allTorrentsFinished();
@@ -559,9 +546,6 @@ namespace BitTorrent
         void trackersRemoved(TorrentHandle *torrent, const QVector<TrackerEntry> &trackers);
         void trackerSuccess(TorrentHandle *torrent, const QString &tracker);
         void trackerWarning(TorrentHandle *torrent, const QString &tracker);
-
-    public slots:
-        void processUnbanRequest();
 
     private slots:
         void configureDeferred();

--- a/src/src.pro
+++ b/src/src.pro
@@ -8,6 +8,7 @@ macx: include(../macxconf.pri)
 unix:!macx: include(../unixconf.pri)
 
 QT += network xml
+QT += sql
 
 nogui {
     TARGET = qbittorrent-nox

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -35,7 +35,6 @@
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
 #include "base/global.h"
-#include "base/logger.h"
 #include "apierror.h"
 
 const char KEY_TRANSFER_DLSPEED[] = "dl_info_speed";
@@ -128,26 +127,4 @@ void TransferController::banPeersAction()
         if (!addr.ip.isNull())
             BitTorrent::Session::instance()->banIP(addr.ip.toString());
     }
-}
-
-void TransferController::tempBlockPeerAction()
-{
-    requireParams({"ip"});
-    QString ip = params()["ip"];
-    const BitTorrent::PeerAddress addr = BitTorrent::PeerAddress::parse(ip);
-    bool isBanned = BitTorrent::Session::instance()->checkAccessFlags(addr.ip.toString());
-
-    if (ip.isEmpty()) {
-        setResult(QLatin1String("IP field should not be empty."));
-        return;
-    }
-
-    if (isBanned) {
-        setResult(QLatin1String("The given IP address already exists."));
-        return;
-    }
-
-    BitTorrent::Session::instance()->tempBlockIP(ip);
-    Logger::instance()->addMessage(tr("Peer '%1' banned via Web API.").arg(ip));
-    setResult(QLatin1String("Done."));
 }

--- a/src/webui/api/transfercontroller.h
+++ b/src/webui/api/transfercontroller.h
@@ -47,5 +47,4 @@ private slots:
     void setUploadLimitAction();
     void setDownloadLimitAction();
     void banPeersAction();
-    void tempBlockPeerAction();
 };


### PR DESCRIPTION
first of all, I liked features provided by this qBittorrent variant, but I think their implementation is far to be optimal. this pull request suggest much more simpler (and cleaner) implementation of peer filtering feature (that's why I found that project).

firstly, few words about currently existing logic. some timer periodically gets list of all connected peers from all torrents and then bans some of them depending on settings and rules. peer ban is achieved by adding "bad peer" IP to libtorrent peer blacklist. this is very inconvenient and expensive: get (and copy) list of already banned IPs known to libtorrent, add new IP (this can cause memory re-allocate operation), and then return modified list to libtorrent (very likely another copy is happen). moreover, iterating over thousands of torrents (and likely peers) on timer may have great performance impact and this is not guarantee that nothing is downloaded by bad peer. this is from performance point of view. from logic point of view, it is very unclear to me why some "unban" timer exists, which unbans peers previously considered "bad" and banned. also from implementation point of view, there are a lot of complex filter conditions in one place and very unclear path how peer is banned.

what I suggest: do NOT **ban peer** using libtorrent "blacklist" API: it is inconvenient and pretty useless - because IP may change, also do NOT use timers to analyze ALL connected peer at one time. instead of that, I suggest just **drop connections** from such "bad" peers on early stage, almost after the moment they establish connection and we consider them "bad". this logic doesn't require "blacklist" editing and handles peers as they arrive (i.e. "on the fly"). in that case NOTHING will be uploaded to banned peers at all. in most cases and few (or even one) rejected connection peers will stop connecting to us, considering us as dead/unreachable or similar. moreover, this logic will perfectly handle IP address changes (same client by with different address will dropped). this behavior can be achieved easily using peer and torrent libttorent extensions. also such implementation is very easily extensible and localized in few separated files, which makes changes moves with upstream version releases more easy.

the filters I implemented is completely the same as original, they are just moved to another place and maybe slightly simplified. behavior is the same, nothing was changed. maybe only one thing to notice - **banned peers are not written to log**, they are **written into SQLITE database**. this is because I don't think that the log is good place to show banned peers, and in my case peers are **not banned**, they **are just dropped**, and such event can happen very often, what will only flood the logs, but database will have only one record per dropped peer.

changes were tested by downloading and seeding about a day 2 torrents from #127 , generated database containing list of banned peers can be [downloaded here](https://www.dropbox.com/s/kintsrlwyixvzn1/peers.db?dl=1).

P.S> I have some more ideas how to improve suggested enhanced feature, very likely I'll open issue (or few) for discussion, because some points of existing implementation are unclear to me. but this is later, I have not so much time to spent on hobby.