### PR TITLE
Fix high CPU usage

### DIFF
--- a/src/base/bittorrent/peer_filter_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_plugin.hpp
@@ -33,36 +33,6 @@ public:
     return peer_plugin::on_extension_handshake(d);
   }
 
-  bool on_interested() override
-  {
-    handle_peer();
-    return peer_plugin::on_interested();
-  }
-
-  bool on_have(lt::piece_index_t p) override
-  {
-    handle_peer();
-    return peer_plugin::on_have(p);
-  }
-
-  bool on_bitfield(lt::bitfield const& bitfield) override
-  {
-    handle_peer();
-    return peer_plugin::on_bitfield(bitfield);
-  }
-
-  bool on_have_all() override
-  {
-    handle_peer();
-    return peer_plugin::on_have_all();
-  }
-
-  bool on_request(lt::peer_request const& r) override
-  {
-    handle_peer();
-    return peer_plugin::on_request(r);
-  }
-
 protected:
   void handle_peer(bool handshake = false)
   {


### PR DESCRIPTION
I discovered new implementation(ban bad peers plugin) can consume lots of CPU resources.
Since each connection has been exchange Peer ID and libtorrent will parse the client name on handshake stage.
So we can remove `on_interested/on_have....`checking handlers.

high CPU usage (when session have many connections, ~800 on my test):
![photo_2020-11-30_05-54-50](https://user-images.githubusercontent.com/5726473/100557520-c3922800-32e4-11eb-826c-cb3a67b46c64.jpg)

After remove (~600 connections):
![{6D9D049C-865B-4A12-9E03-690FB320F88A}](https://user-images.githubusercontent.com/5726473/100565358-5ee3c700-32fe-11eb-9e3c-855965ac7e23.png)

Please feel free to test and post your test result here.