### PR TITLE
peer filtering refactor and cleanup

### DIFF
--- a/src/base/bittorrent/peer_filter_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_plugin.hpp
@@ -68,22 +68,3 @@ private:
   filter_function m_filter;
   action_function m_action;
 };
-
-
-class peer_action_plugin_creator
-{
-public:
-  peer_action_plugin_creator(filter_function filter, action_function action)
-    : m_filter(std::move(filter))
-    , m_action(std::move(action))
-  {}
-
-  std::shared_ptr<lt::torrent_plugin> operator()(lt::torrent_handle const&, void*)
-  {
-    return std::make_shared<peer_action_plugin>(m_filter, m_action);
-  }
-
-private:
-  filter_function m_filter;
-  action_function m_action;
-};


### PR DESCRIPTION
- drop useless peer plugin factory class, created simple factory function instead
- don't use QSqlTableModel for db access, used QSqlQuery instead, this will save some memory (why to keep all records contain banned peers info in memory? let's just write them to db and forget!)

no any logic neither db structure changes were made, just small refactoring and cleanup. these changes are result of heavy testing of 'peer whitelist' feature I'm working on for my server. very likely I'll share it later (it is still not ready and have to be polished).

moreover, during this experiments/implementation I found QSqlTableModel unreliable and behave unexpectedly comparing for other 'out of the box' models, so I decided do not use it and use simple queries like in Python. this also decreased the count of required code lines.