### PR TITLE
Fix AppImage build and add x86_64-w64-mingw32 build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -65,10 +65,9 @@ jobs:
           - cross_host: x86_64-linux-musl
             openssl_compiler: linux-x86_64
             qt_device: linux-generic-g++
-          # TODO: Support x86_64-w64-mingw32
-          # - cross_host: x86_64-w64-mingw32
-          #   openssl_compiler: mingw64
-          #   qt_xplatform: win32-g++
+          - cross_host: x86_64-w64-mingw32
+            openssl_compiler: mingw64
+            qt_xplatform: win32-g++
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -11,13 +11,14 @@ on:
 
 jobs:
   appimage:
-    runs-on: ubuntu-latest
-    container: "ubuntu:16.04"
+    runs-on: ubuntu-16.04
+    # Waiting https://github.com/linuxdeploy/linuxdeploy/issues/154 fixed
+    # container: "ubuntu:16.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build AppImage
-        run: .github/workflows/build_appimage.sh
+        run:  sudo .github/workflows/build_appimage.sh
       - uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-Enhanced-Edition.AppImage

--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -52,7 +52,7 @@ apt install -y --no-install-suggests --no-install-recommends \
 SELF_DIR="$(dirname "$(readlink -f "${0}")")"
 
 # install qt
-curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop latest gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
+curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop 5.15.2 gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
 export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
 export QTDIR=$QT_BASE_DIR
 export PATH=$QT_BASE_DIR/bin:$PATH
@@ -82,7 +82,7 @@ make install -j$(nproc)
 [ -x "/tmp/linuxdeploy-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
 [ -x "/tmp/linuxdeploy-plugin-qt-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-plugin-qt-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 chmod -v +x '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
-# Fix run in docker, see: https://github.com/linuxdeploy/linuxdeploy/issues/104
+# Fix run in docker, see: https://github.com/linuxdeploy/linuxdeploy/issues/86
 sed -i 's|AI\x02|\x00\x00\x00|' '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
 cd "/tmp/qbee"
 mkdir -p "/tmp/qbee/AppDir/apprun-hooks/"

--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -15,7 +15,6 @@
 
 apt update
 apt install -y software-properties-common
-apt-add-repository -y ppa:mhier/libboost-latest
 apt-add-repository -y ppa:savoury1/backports
 apt update
 apt install -y --no-install-suggests --no-install-recommends \
@@ -27,18 +26,15 @@ apt install -y --no-install-suggests --no-install-recommends \
   automake \
   pkg-config \
   file \
-  libgl1-mesa-dev \
-  libegl1-mesa-dev \
-  libdbus-1-dev \
   zlib1g-dev \
   libssl-dev \
   libtool \
-  libboost1.74-dev \
   python3-semantic-version \
   python3-lxml \
   python3-requests \
   p7zip-full \
   libfontconfig1 \
+  libgl1-mesa-dev \
   libxcb-icccm4 \
   libxcb-image0 \
   libxcb-keysyms1 \
@@ -46,13 +42,21 @@ apt install -y --no-install-suggests --no-install-recommends \
   libxcb-xinerama0 \
   libxcb-xkb1 \
   libxkbcommon-x11-0 \
-  unixodbc-dev \
-  libpq-dev
+  libpq5 \
+  libxcb-randr0 \
+  libxcb-shape0 \
+  libodbc1 \
+  libxcb-xfixes0 \
+  libegl1-mesa
 
+# Force refresh ld.so.cache
+ldconfig
 SELF_DIR="$(dirname "$(readlink -f "${0}")")"
 
 # install qt
-curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop 5.15.2 gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
+if [ ! -d "${HOME}/Qt" ]; then
+  curl -sSkL --compressed https://raw.githubusercontent.com/engnr/qt-downloader/master/qt-downloader | python3 - linux desktop 5.15.2 gcc_64 -o "${HOME}/Qt" -m qtbase qttools qtsvg icu
+fi
 export QT_BASE_DIR="$(ls -rd "${HOME}/Qt"/*/gcc_64 | head -1)"
 export QTDIR=$QT_BASE_DIR
 export PATH=$QT_BASE_DIR/bin:$PATH
@@ -61,6 +65,17 @@ export PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
 export QT_QMAKE="${QT_BASE_DIR}/bin"
 sed -i.bak 's/Enterprise/OpenSource/g;s/licheck.*//g' "${QT_BASE_DIR}/mkspecs/qconfig.pri"
 
+# build latest boost
+mkdir -p /usr/src/boost
+if [ ! -f /usr/src/boost/.unpack_ok ]; then
+  boost_latest_url="$(curl -ksSfL https://www.boost.org/users/download/ | grep -o 'http[^"]*.tar.bz2' | head -1)"
+  curl -ksSfL "${boost_latest_url}" | tar -jxf - -C /usr/src/boost --strip-components 1
+fi
+touch "/usr/src/boost/.unpack_ok"
+cd /usr/src/boost
+./bootstrap.sh
+./b2 install --with-system variant=release
+
 # build libtorrent-rasterbar
 mkdir -p /usr/src/libtorrent-rasterbar
 [ -f /usr/src/libtorrent-rasterbar/.unpack_ok ] ||
@@ -68,14 +83,14 @@ mkdir -p /usr/src/libtorrent-rasterbar
   tar -zxf - -C /usr/src/libtorrent-rasterbar --strip-components 1
 touch "/usr/src/libtorrent-rasterbar/.unpack_ok"
 cd "/usr/src/libtorrent-rasterbar/"
-CXXFLAGS="-std=c++14" CPPFLAGS="-std=c++14" ./bootstrap.sh --prefix=/usr --with-boost-libdir="/usr/lib" --disable-debug --disable-maintainer-mode --with-libiconv
+CXXFLAGS="-std=c++14" CPPFLAGS="-std=c++14" ./bootstrap.sh --prefix=/usr --with-boost="/usr/local" --with-boost-libdir="/usr/local/lib" --disable-debug --disable-maintainer-mode --with-libiconv
 make clean
 make -j$(nproc)
 make install
 
 # build qbittorrent
 cd "${SELF_DIR}/../../"
-./configure --prefix=/tmp/qbee/AppDir/usr --with-boost-libdir="/usr/lib" || (cat config.log && exit 1)
+./configure --prefix=/tmp/qbee/AppDir/usr --with-boost="/usr/local" --with-boost-libdir="/usr/local/lib" || (cat config.log && exit 1)
 make install -j$(nproc)
 
 # build AppImage
@@ -83,7 +98,7 @@ make install -j$(nproc)
 [ -x "/tmp/linuxdeploy-plugin-qt-x86_64.AppImage" ] || curl -LC- -o /tmp/linuxdeploy-plugin-qt-x86_64.AppImage "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 chmod -v +x '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
 # Fix run in docker, see: https://github.com/linuxdeploy/linuxdeploy/issues/86
-sed -i 's|AI\x02|\x00\x00\x00|' '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
+# sed -i 's|AI\x02|\x00\x00\x00|' '/tmp/linuxdeploy-plugin-qt-x86_64.AppImage' '/tmp/linuxdeploy-x86_64.AppImage'
 cd "/tmp/qbee"
 mkdir -p "/tmp/qbee/AppDir/apprun-hooks/"
 echo 'export XDG_DATA_DIRS="${APPDIR:-"$(dirname "${BASH_SOURCE[0]}")/.."}/usr/share:${XDG_DATA_DIRS}:/usr/share:/usr/local/share"' >"/tmp/qbee/AppDir/apprun-hooks/xdg_data_dirs.sh"


### PR DESCRIPTION
AppImage 改到VM直接build，以规避 linuxdeploy 在docker环境下运行目前的各种BUG(比如这个 https://github.com/linuxdeploy/linuxdeploy/issues/154 )。

手打一些补丁，以便于x86_64-w64-mingw32 可以正常构建，但是目前似乎没什么卵用，因为qbittorrent-nox似乎对Windows的terminal并没有什么适配，在终端运行会无法看到输出，实际程序是已经在后台运行的，在wine环境下无此问题。暂时先保留这个构建吧，说不定未来qbittorrent-nox官方支持windows环境就可以直接用了