### PR TITLE
peer blacklist optimizations and cleanup

### DIFF
--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -49,30 +49,6 @@ void drop_connection(lt::peer_connection_handle ph)
 }
 
 
-class peer_logger_singleton
-{
-public:
-  static peer_logger_singleton& instance()
-  {
-    static peer_logger_singleton logger;
-    return logger;
-  }
-
-  void log_peer(const lt::peer_info& info, const std::string& tag)
-  {
-    m_logger.log_peer(info, tag);
-  }
-
-protected:
-  peer_logger_singleton()
-    : m_logger(db_connection::instance().connection(), QStringLiteral("banned_peers"))
-  {}
-
-private:
-  peer_logger m_logger;
-};
-
-
 template<typename F>
 auto wrap_filter(F filter, const std::string& tag)
 {

--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -12,10 +12,9 @@
 // bad peer filter
 bool is_bad_peer(const lt::peer_info& info)
 {
-  std::string pid = info.pid.to_string().substr(0, 8);
   std::regex id_filter("-(XL|SD|XF|QD|BN|DL)(\\d+)-");
   std::regex ua_filter(R"((\d+.\d+.\d+.\d+|cacao_torrent))");
-  return std::regex_match(pid, id_filter) || std::regex_match(info.client, ua_filter);
+  return std::regex_match(info.pid.data(), info.pid.data() + 8, id_filter) || std::regex_match(info.client, ua_filter);
 }
 
 // Unknown Peer filter
@@ -36,9 +35,8 @@ bool is_offline_downloader(const lt::peer_info& info)
 // BitTorrent Media Player Peer filter
 bool is_bittorrent_media_player(const lt::peer_info& info)
 {
-  std::string pid = info.pid.to_string().substr(0, 8);
   std::regex player_filter("-(UW\\w{4})-");
-  return !!std::regex_match(pid, player_filter);
+  return !!std::regex_match(info.pid.data(), info.pid.data() + 8, player_filter);
 }
 
 

--- a/src/base/bittorrent/peer_logger.hpp
+++ b/src/base/bittorrent/peer_logger.hpp
@@ -77,3 +77,27 @@ private:
   QSqlDatabase m_db;
   QString m_table;
 };
+
+
+class peer_logger_singleton
+{
+public:
+  static peer_logger_singleton& instance()
+  {
+    static peer_logger_singleton logger;
+    return logger;
+  }
+
+  void log_peer(const lt::peer_info& info, const std::string& tag)
+  {
+    m_logger.log_peer(info, tag);
+  }
+
+protected:
+  peer_logger_singleton()
+    : m_logger(db_connection::instance().connection(), QStringLiteral("banned_peers"))
+  {}
+
+private:
+  peer_logger m_logger;
+};

--- a/src/base/bittorrent/peer_logger.hpp
+++ b/src/base/bittorrent/peer_logger.hpp
@@ -68,7 +68,7 @@ public:
     q.prepare(QString("INSERT INTO '%1' (ip, client, pid, tag) VALUES (?, ?, ?, ?)").arg(m_table));
     q.addBindValue(QString::fromStdString(info.ip.address().to_string()));
     q.addBindValue(QString::fromStdString(info.client));
-    q.addBindValue(QString::fromStdString(info.pid.to_string().substr(0, 8)));
+    q.addBindValue(QString::fromLatin1(info.pid.data(), 8));
     q.addBindValue(QString::fromStdString(tag));
     return q.exec();
   }


### PR DESCRIPTION
it doesn't change any behavior, it is just some cleanup:

- do not create std::string with peer id in filters
- do not do substr() in logger, directly create string instead
- moved peer_logger_singleton to peer_logger.hpp

first 2 points should slightly affect performance, because it decreases number of memory allocations (and copy operations) during string creation and std::string -> QString conversions. memory allocations are heavy, and due to places where they happen, a lot of such operations are executed even in small interval (especially when a lot of torrents are active or torrents are very popular), so these small changes can noticeable decrease CPU usage (few percents) or at least decrease memory fragmentation and filter function execution time.

the last point is mostly cosmetic, but I decided also to attach this, because moved part looks like a part of logger itself, but was in filter implementation file rather than nearby logger implementation.

all where tested, I added ~10 torrents with pretty much peers, downloaded them and seeded for some time (just few minutes). here is screenshot from DB viewer software listed part of table with dropped (banned) peers:
![Screenshot at 2021-03-28 22-55-58](https://user-images.githubusercontent.com/947647/112766560-05c14100-901b-11eb-8f05-783806d52010.png)
as you can see, there are few records from modified filter functions, so they work fine.

P.S> these changes were made as part of work on improvement I mentioned a long time ago and what is finally ready to be shared and will be published for discussion in few days. few more PRs with small independent changes (like in this PR) also may appear.