### PR TITLE
improved peer logger table creation statement

### DIFF
--- a/src/base/bittorrent/peer_logger.hpp
+++ b/src/base/bittorrent/peer_logger.hpp
@@ -51,12 +51,11 @@ public:
     if (!db.tables().contains(table)) {
       db.exec(QString(
                 "CREATE TABLE '%1' ("
-                "    'id'      INTEGER NOT NULL UNIQUE,"
+                "    'id'      INTEGER PRIMARY KEY,"
                 "    'ip'      TEXT NOT NULL UNIQUE,"
-                "    'client'  TEXT,"
-                "    'pid'     TEXT,"
-                "    'tag'     TEXT,"
-                "    PRIMARY KEY('id' AUTOINCREMENT)"
+                "    'client'  TEXT NOT NULL,"
+                "    'pid'     BLOB NOT NULL,"
+                "    'tag'     TEXT"
                 ");").arg(table));
       db.commit();
     }


### PR DESCRIPTION
- do use AUTOINCREMENT keyword, use available INTEGER PRIMARY KEY, it has "autoincrement feature" out of the box
- use BLOB type for peer id, this is more correct - we store bytes, and it doesn't add any restrictions to data type
- require client and peer id columns to be NOT NULL

these changes does NOT affect any existing users (database already created and table has some data), any existing database will be used as is, because table structure was not changed

changes were tested in both scenarios: db from previous version exits and completely fresh run (no db exists)