### PR TITLE
peer whitelist

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(qbt_base STATIC
     bittorrent/peer_blacklist.hpp
     bittorrent/peer_filter_plugin.hpp
     bittorrent/peer_logger.hpp
+    bittorrent/peer_whitelist.hpp
     bittorrent/portforwarderimpl.cpp
     bittorrent/resumedatasavingmanager.cpp
     bittorrent/session.cpp

--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -50,8 +50,9 @@ void drop_connection(lt::peer_connection_handle ph)
 template<typename F>
 auto wrap_filter(F filter, const std::string& tag)
 {
-  return [=](const lt::peer_info& info, bool) {
+  return [=](const lt::peer_info& info, bool handshake, bool* stop_filtering) {
     bool matched = filter(info);
+    *stop_filtering = !handshake && !matched;
     if (matched)
       peer_logger_singleton::instance().log_peer(info, tag);
     return matched;

--- a/src/base/bittorrent/peer_whitelist.hpp
+++ b/src/base/bittorrent/peer_whitelist.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+#include <QDir>
+#include <QRegularExpression>
+#include <QString>
+#include <QVector>
+
+#include <libtorrent/peer_info.hpp>
+
+#include "base/profile.h"
+
+#include "peer_filter_plugin.hpp"
+#include "peer_logger.hpp"
+
+
+namespace {
+
+bool qregex_has_match(const QRegularExpression& re, const QString& str)
+{
+  auto m = re.match(str);
+  return m.hasMatch();
+}
+
+}
+
+class peer_filter
+{
+public:
+  explicit peer_filter(const QString& filter_file)
+  {
+    std::ifstream ifs(filter_file.toStdString());
+    std::string peer_id, client;
+    while (ifs >> peer_id >> client)
+      m_filters.append({QRegularExpression(QString::fromStdString(peer_id)),
+                        QRegularExpression(QString::fromStdString(client))});
+  }
+
+  bool match_peer(const lt::peer_info& info, bool skip_name) const
+  {
+    QString peer_id = QString::fromLatin1(info.pid.data(), 8);
+    QString client = QString::fromStdString(info.client);
+    return std::any_of(m_filters.begin(), m_filters.end(),
+                       [&](const auto& filter) {
+                           return qregex_has_match(filter[0], peer_id) &&
+                               (skip_name || qregex_has_match(filter[1], client));
+                       });
+  }
+
+private:
+  QVector<QVector<QRegularExpression>> m_filters;
+};
+
+
+std::shared_ptr<lt::torrent_plugin> create_peer_whitelist_plugin(lt::torrent_handle const&, void*)
+{
+  QDir qbt_data_dir(specialFolderLocation(SpecialFolder::Data));
+
+  QString filter_file = qbt_data_dir.absoluteFilePath(QStringLiteral("peer_whitelist.txt"));
+  // do not create plugin if filter file doesn't exists
+  if (!QFile::exists(filter_file))
+    return nullptr;
+
+  // create filter object only once
+  static peer_filter filter(filter_file);
+
+  auto peer_not_in_list = [&](const lt::peer_info& info, bool handshake, bool* stop_filtering) {
+    bool matched = filter.match_peer(info, handshake);
+    *stop_filtering = !handshake && matched;
+    if (!matched)
+      peer_logger_singleton::instance().log_peer(info, "whitelist");
+    return !matched;
+  };
+
+  auto drop_connection = [](lt::peer_connection_handle p) {
+    p.disconnect(boost::asio::error::connection_refused,
+                 lt::operation_t::bittorrent,
+                 lt::disconnect_severity_t{0});
+  };
+
+  return std::make_shared<peer_action_plugin>(std::move(peer_not_in_list), std::move(drop_connection));
+}

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -97,6 +97,7 @@
 #include "magneturi.h"
 #include "nativesessionextension.h"
 #include "peer_blacklist.hpp"
+#include "peer_whitelist.hpp"
 #include "portforwarderimpl.h"
 #include "resumedatasavingmanager.h"
 #include "statistics.h"
@@ -1206,6 +1207,7 @@ void Session::initializeNativeSession()
     }
     if (isAutoBanBTPlayerPeerEnabled())
         m_nativeSession->add_extension(&create_drop_bittorrent_media_player_plugin);
+    m_nativeSession->add_extension(&create_peer_whitelist_plugin);
 
     m_nativeSession->add_extension(std::make_shared<NativeSessionExtension>());
 }


### PR DESCRIPTION
implemented peer whitelist feature: user can define a list of expressions describing peers (peer id + client name) allowed to connect, everything that didn't match these rules is dropped (connection is closed). suggested peer whitelist is also attached.

why: initially I wanted to drop connections from specific clients on my server, but found that there are a lot of clients with very different peer id but the same client name, or even with peer id containing just a set of random bytes (do not following any rules), so just blacklisting (banning) them is pretty problematic. allowing something and ban anything else is much simpler solution.

why I decided to check client names: there are a lot of strange clients representing itself as uTorrent (very often with insane version) or qBittorrent (usually real version) according to its peer id, but when handshake is passed and real client name is already known (string actually reported by peer, not just resolved by libtorrent based on peer id), such clients very often report that they are "libtorrent 1.1.x" or "libtorrent 1.2.x". so, just checking peer id is not enough to distinguish such clients.

see attached screenshot, here you can find some "uTorrent 5.x.y" or "uTorrent 6.x.y" clients and clients with random peer id. these screenshots from the times I collected statistics to create suitable peer whitelist, and also I was very curious what connects to my server. now I don't have code that collects such info, and info collected by that filter is not enough.

![Screenshot at 2021-01-07 19-09-17](https://user-images.githubusercontent.com/947647/112809511-c1698b80-9082-11eb-845b-e15011f797ab.png)
![Screenshot at 2021-01-07 19-10-58](https://user-images.githubusercontent.com/947647/112809553-ca5a5d00-9082-11eb-84d1-0db359a8d18b.png)

this extension/filter was created long time ago (at the beginning of December 2020), and was thoroughly tested. suggested peer whitelist was created based on statistics collected by my server with ~2k torrents during these few months. suggested peer whitelist is good enough for average user, it covers +/- well-known and "ideologically true" desktop and mobile (Android) clients.

whitelist rules are placed in external file 'peer_whitelist.txt', located in qBittorrent data directory ($HOME/.local/share/qBittorrent in case of Linux). if there is NO such file plugin is not activated. but beware, placing an empty file will drop all connections!

peer whitelist syntax is very simple - each rule is just a line containing 2 Perl-compliant regular expressions: one for peer id (first), another - for client name. tabs or spaces can be used as separator for expressions.

there is one restrictions to expressions - spaces can't be used. this is due to very simple syntax and parser for it. use `\s` in expressions to describe space.

everything in file is parsed! there are no any comments support, so be careful! invalid expressions just lead to not working one rule containing them, other rules keep working fine.

suggested peer whitelist (and this works on my server):
```
-BC01\d{2}-                         BitComet\s\d(\.\d+){1,3}
-BT[67]\w{3}-                       BitTorrent\s\d(\.\d+){1,3}
-DE[1-2]\w{3}-                      Deluge[\/\s]\d(\.\d+){2,3}(.*)?
-KT\w{4}-                           KTorrent[\/\s]\d\.\d(\.\d+){0,2}(dev)?
-TR[1-3]\w{3}-                      Transmission[\/\s]\d\.\d+(\.\d+)?$
-qB[3-4]\w{3}-                      qBittorrent[\/\s]v?\d\.\d\.\d+(\.\d+)?(\S+)?
-qB[3-4]\w{3}-                      qBittorrent(\sEnhanced)?[\/\s]\d(\.\d+){3}
-lt0\w{3}-                          (r|lib)Torrent\s0\.\d+\.\d+
TIX02\d{2}-                         Tixati(\s\d\.\d+)?
-UT(1[0-8]\d|2[0-2]\d|3[0-5]\d)\w-  [u\N{U+00B5}\N{U+03BC}]Torrent\s\d(\.\d+){1,3}
-UM1\w{3}-                          [u\N{U+00B5}\N{U+03BC}]Torrent\sMac\s1(\.\d+){1,2}
-Lr[1-3].{3}-                       LibreTorrent\s\d(\.\d+){1,3}(.*)?
-tT1\w{3}-                          tTorrent\sv\d(\.\d+){1,3}
```