### PR TITLE
fixed few warnings

### DIFF
--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -4,6 +4,8 @@
 
 #include <libtorrent/torrent_info.hpp>
 
+#include <QHostAddress>
+
 #include "base/net/geoipmanager.h"
 
 #include "peer_filter_plugin.hpp"

--- a/src/base/bittorrent/peer_logger.hpp
+++ b/src/base/bittorrent/peer_logger.hpp
@@ -5,6 +5,8 @@
 #include <QSqlDatabase>
 #include <QSqlQuery>
 
+#include <QVariant>
+
 
 class db_connection
 {

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -451,10 +451,6 @@ Session::Session(QObject *parent)
     , m_peerTurnover(BITTORRENT_SESSION_KEY("PeerTurnover"), 4)
     , m_peerTurnoverCutoff(BITTORRENT_SESSION_KEY("PeerTurnoverCutOff"), 90)
     , m_peerTurnoverInterval(BITTORRENT_SESSION_KEY("PeerTurnoverInterval"), 300)
-    , m_autoBanUnknownPeer(BITTORRENT_SESSION_KEY("AutoBanUnknownPeer"), false)
-    , m_autoBanBTPlayerPeer(BITTORRENT_SESSION_KEY("AutoBanBTPlayerPeer"), false)
-    , m_isAutoUpdateTrackersEnabled(BITTORRENT_SESSION_KEY("AutoUpdateTrackersEnabled"), false)
-    , m_publicTrackers(BITTORRENT_SESSION_KEY("PublicTrackersList"))
     , m_bannedIPs("State/BannedIPs"
                   , QStringList()
                   , [](const QStringList &value)
@@ -464,6 +460,10 @@ Session::Session(QObject *parent)
                             return tmp;
                         }
                  )
+    , m_publicTrackers(BITTORRENT_SESSION_KEY("PublicTrackersList"))
+    , m_autoBanUnknownPeer(BITTORRENT_SESSION_KEY("AutoBanUnknownPeer"), false)
+    , m_autoBanBTPlayerPeer(BITTORRENT_SESSION_KEY("AutoBanBTPlayerPeer"), false)
+    , m_isAutoUpdateTrackersEnabled(BITTORRENT_SESSION_KEY("AutoUpdateTrackersEnabled"), false)
 #if defined(Q_OS_WIN)
     , m_OSMemoryPriority(BITTORRENT_KEY("OSMemoryPriority"), OSMemoryPriority::BelowNormal)
 #endif

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -508,10 +508,6 @@ namespace BitTorrent
         void setPublicTrackers(const QString &trackers);
         void updatePublicTracker();
 
-        // Enhanced Function
-        CachedSettingValue<QString> m_publicTrackers;
-        QTimer *m_updateTimer;
-
     signals:
         void allTorrentsFinished();
         void categoryAdded(const QString &categoryName);
@@ -763,9 +759,12 @@ namespace BitTorrent
 #if defined(Q_OS_WIN)
         CachedSettingValue<OSMemoryPriority> m_OSMemoryPriority;
 #endif
+        // Enhanced Function
+        CachedSettingValue<QString> m_publicTrackers;
         CachedSettingValue<bool> m_autoBanUnknownPeer;
         CachedSettingValue<bool> m_autoBanBTPlayerPeer;
         CachedSettingValue<bool> m_isAutoUpdateTrackersEnabled;
+        QTimer *m_updateTimer;
 
         // Order is important. This needs to be declared after its CachedSettingsValue
         // counterpart, because it uses it for initialization in the constructor


### PR DESCRIPTION
- fixed initialization order '-Worder'
- added missed headers detected by static analyzers

mentioned issues were found during build on macOS