### PR TITLE
improved peerID() implementation

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -182,7 +182,12 @@ QString PeerInfo::client() const
 
 QString PeerInfo::peerId() const
 {
-    return QString::fromStdString(m_nativeInfo.pid.to_string());
+    // when peer ID is not known yet it contains only zero bytes,
+    // do not create string in such case, return empty string instead
+    if (*reinterpret_cast<const quint64*>(m_nativeInfo.pid.data()) == 0)
+        return {};
+    // peer ID in only first 8 bytes, the rest is not interesting
+    return QString::fromLatin1(m_nativeInfo.pid.data(), 8);
 }
 
 qreal PeerInfo::progress() const

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -463,7 +463,7 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
     setModelData(row, PeerListColumns::FLAGS, peer.flags(), peer.flags(), {}, peer.flagsDescription());
     const QString client = peer.client().toHtmlEscaped();
     setModelData(row, PeerListColumns::CLIENT, client, client);
-    const QString peerId = peer.peerId().left(8).toHtmlEscaped();
+    const QString peerId = peer.peerId().toHtmlEscaped();
     setModelData(row, PeerListColumns::PEERID, peerId, peerId);
     setModelData(row, PeerListColumns::PROGRESS, (Utils::String::fromDouble(peer.progress() * 100, 1) + '%'), peer.progress(), intDataTextAlignment);
     const QString downSpeed = (hideValues && (peer.payloadDownSpeed() <= 0)) ? QString {} : Utils::Misc::friendlyUnit(peer.payloadDownSpeed(), true);

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -565,7 +565,7 @@ void SyncController::torrentPeersAction()
             {KEY_PEER_IP, pi.address().ip.toString()},
             {KEY_PEER_PORT, pi.address().port},
             {KEY_PEER_CLIENT, pi.client()},
-            {KEY_PEER_ID, pi.peerId().left(8)},
+            {KEY_PEER_ID, pi.peerId()},
             {KEY_PEER_PROGRESS, pi.progress()},
             {KEY_PEER_DOWN_SPEED, pi.payloadDownSpeed()},
             {KEY_PEER_UP_SPEED, pi.payloadUpSpeed()},


### PR DESCRIPTION
- do not do substring operations where peer ID is required
- create peer ID string from first 8 bytes of peer ID buffer
- return empty string when peer ID is not known yet

this avoids a lot of unnecessary memory copies and allocations

also prevents various GUI artifacts caused by zero-bytes strings:
- abnormal row height in peers list on macOS
- square symbols in peer ID column on Linux

no changes (v4_3_x as is):
<img width="1440" alt="Screen Shot 2021-04-18 at 11 21 35" src="https://user-images.githubusercontent.com/947647/115141819-06139180-a047-11eb-81bd-9b74abde3b1c.png">

with changes:
<img width="1440" alt="Screen Shot 2021-04-18 at 12 53 45" src="https://user-images.githubusercontent.com/947647/115141834-11ff5380-a047-11eb-955f-dbe66d3e13d0.png">
