### PR TITLE
prepare custom filter extensions for libtorrent 2.0

### DIFF
--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -77,22 +77,22 @@ std::shared_ptr<lt::torrent_plugin> create_peer_action_plugin(
 
 // plugins factory functions
 
-std::shared_ptr<lt::torrent_plugin> create_drop_bad_peers_plugin(lt::torrent_handle const& th, void*)
+std::shared_ptr<lt::torrent_plugin> create_drop_bad_peers_plugin(lt::torrent_handle const& th, client_data)
 {
   return create_peer_action_plugin(th, wrap_filter(is_bad_peer, "bad peer"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_unknown_peers_plugin(lt::torrent_handle const& th, void*)
+std::shared_ptr<lt::torrent_plugin> create_drop_unknown_peers_plugin(lt::torrent_handle const& th, client_data)
 {
   return create_peer_action_plugin(th, wrap_filter(is_unknown_peer, "unknown peer"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_offline_downloader_plugin(lt::torrent_handle const& th, void*)
+std::shared_ptr<lt::torrent_plugin> create_drop_offline_downloader_plugin(lt::torrent_handle const& th, client_data)
 {
   return create_peer_action_plugin(th, wrap_filter(is_offline_downloader, "offline downloader"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_bittorrent_media_player_plugin(lt::torrent_handle const& th, void*)
+std::shared_ptr<lt::torrent_plugin> create_drop_bittorrent_media_player_plugin(lt::torrent_handle const& th, client_data)
 {
   return create_peer_action_plugin(th, wrap_filter(is_bittorrent_media_player, "bittorrent media player"), drop_connection);
 }

--- a/src/base/bittorrent/peer_filter_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_plugin.hpp
@@ -3,6 +3,12 @@
 #include <libtorrent/extensions.hpp>
 #include <libtorrent/peer_connection_handle.hpp>
 
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+using client_data = lt::client_data_t;
+#else
+using client_data = void*;
+#endif
+
 using filter_function = std::function<bool(const lt::peer_info&, bool, bool*)>;
 using action_function = std::function<void(lt::peer_connection_handle)>;
 

--- a/src/base/bittorrent/peer_whitelist.hpp
+++ b/src/base/bittorrent/peer_whitelist.hpp
@@ -71,7 +71,7 @@ private:
 };
 
 
-std::shared_ptr<lt::torrent_plugin> create_peer_whitelist_plugin(lt::torrent_handle const&, void*)
+std::shared_ptr<lt::torrent_plugin> create_peer_whitelist_plugin(lt::torrent_handle const&, client_data)
 {
   QDir qbt_data_dir(specialFolderLocation(SpecialFolder::Data));
 


### PR DESCRIPTION
official 4.3.x already has libtorrent 2.0 support, but custom filter extensions (blacklist/whitelist) presented here relied on libtorrent 1.2.x API. fortunately the fix is very simple, and it was picked from official qbittorrent 4.3.x branch.

P.S> from my personal experience, it is completely safe to use libtorrent 2.0 now, qBittorrent already supports it, there were only few issues regarding libtorrent 2.0 on their GitHub page. moreover, even in case of rollback to 1.2.x there is nothing required - lt 1.2 successfully reads .fastresume data saved by lt 2.0, so backward compatibility is present "out of the box".
upgrade to lt 2.0 also does not require any heavy migration process (very likely nothing happens at all) - all existing .fastresume data saved by lt 1.2 successfully loaded.

changes were made and tested on macOS machine, not yet tested on Linux (but should not cause problems), don't have Windows machine suitable for development