### PR TITLE
Use libtorrent 2.0 for release building

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -11,14 +11,13 @@ on:
 
 jobs:
   appimage:
-    runs-on: ubuntu-16.04
-    # Waiting https://github.com/linuxdeploy/linuxdeploy/issues/154 fixed
-    # container: "ubuntu:16.04"
+    runs-on: ubuntu-latest
+    container: "ubuntu:16.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build AppImage
-        run:  sudo .github/workflows/build_appimage.sh
+        run:  .github/workflows/build_appimage.sh
       - uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-Enhanced-Edition.AppImage
@@ -66,9 +65,9 @@ jobs:
           - cross_host: x86_64-linux-musl
             openssl_compiler: linux-x86_64
             qt_device: linux-generic-g++
-          - cross_host: x86_64-w64-mingw32
-            openssl_compiler: mingw64
-            qt_xplatform: win32-g++
+#          - cross_host: x86_64-w64-mingw32
+#            openssl_compiler: mingw64
+#            qt_xplatform: win32-g++
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Seems that libtorrent 2.0 is working now. So switch libtorrent 2.0 for release building.

