### PR TITLE
fix zsync Filename entity for AppImage

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -30,16 +30,14 @@ jobs:
         run: .github/workflows/build_appimage.sh
       - uses: actions/upload-artifact@v2
         with:
-          name: qBittorrent-Enhanced-Edition.AppImage
-          path: |
-            .github/workflows/qBittorrent-Enhanced-Edition.AppImage
-            .github/workflows/qBittorrent-Enhanced-Edition.AppImage.zsync
+          name: qBittorrent-Enhanced-Edition-x86_64.AppImage
+          path: ".github/workflows/qBittorrent-Enhanced-Edition*.AppImage*"
       - name: Upload Github Assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ".github/workflows/qBittorrent-Enhanced-Edition.AppImage*"
+          file: ".github/workflows/qBittorrent-Enhanced-Edition*.AppImage*"
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -356,15 +356,18 @@ exclude_libs=(
   libwayland-egl.so.1
 )
 
+# fix AppImage output file name
+sed -i 's/Name=qBittorrent.*/Name=qBittorrent-Enhanced-Edition/' /tmp/qbee/AppDir/usr/share/applications/*.desktop
+
 APPIMAGE_EXTRACT_AND_RUN=1 \
   /tmp/linuxdeployqt-continuous-x86_64.AppImage \
   /tmp/qbee/AppDir/usr/share/applications/*.desktop \
   -always-overwrite \
   -appimage \
   -no-copy-copyright-files \
-  -updateinformation="zsync|https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage.zsync" \
+  -updateinformation="zsync|https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/qBittorrent-Enhanced-Edition-x86_64.AppImage.zsync" \
   -extra-plugins="$(join_by ',' "${extra_plugins[@]}")" \
   -exclude-libs="$(join_by ',' "${exclude_libs[@]}")"
 
-cp -fv /tmp/qbee/qBittorrent-x86_64.AppImage "${SELF_DIR}/qBittorrent-Enhanced-Edition.AppImage"
-cp -fv /tmp/qbee/qBittorrent-x86_64.AppImage.zsync "${SELF_DIR}/qBittorrent-Enhanced-Edition.AppImage.zsync"
+# output file name should be qBittorrent-Enhanced-Edition-x86_64.AppImage
+cp -fv /tmp/qbee/qBittorrent-Enhanced-Edition*.AppImage* "${SELF_DIR}/"

--- a/.github/workflows/cross_build.sh
+++ b/.github/workflows/cross_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# This scrip is for building AppImage
+# This scrip is for static cross compiling
 # Please run this scrip in docker image: ubuntu:20.04
 # E.g: docker run --rm -v `git rev-parse --show-toplevel`:/build ubuntu:20.04 /build/.github/workflows/cross_build.sh
 # If you need keep store build cache in docker volume, just like:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ will install and execute qBittorrent hopefully without any problem.
 
 If you are using a desktop Linux distribution without any special demands, you can use AppImage from release page.
 
-Latest AppImage download: [qBittorrent-Enhanced-Edition.AppImage](https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/latest/download/qBittorrent-Enhanced-Edition.AppImage)
+Latest AppImage download: [qBittorrent-Enhanced-Edition-x86_64.AppImage](https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/latest/download/qBittorrent-Enhanced-Edition-x86_64.AppImage)
 
 #### Arch Linux (Maintainer: [c0re100](https://github.com/c0re100))
 


### PR DESCRIPTION
Rename AppImage filename to `qBittorrent-Enhanced-Editon-x86_64.AppImage` to fix zsync update information filename wrong.