### PR TITLE
fix appimage build

### DIFF
--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -33,6 +33,9 @@ rm -f /etc/apt/apt.conf.d/*
 echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/01keep-debs
 echo -e 'Acquire::https::Verify-Peer "false";\nAcquire::https::Verify-Host "false";' >/etc/apt/apt.conf.d/99-trust-https
 
+# Since cmake 3.23.0 CMAKE_INSTALL_LIBDIR will force set to lib/<multiarch-tuple> on Debian
+echo '/usr/local/lib/x86_64-linux-gnu' > /etc/ld.so.conf.d/x86_64-linux-gnu-local.conf
+
 apt update
 apt install -y software-properties-common apt-transport-https
 apt-add-repository -y ppa:savoury1/backports


### PR DESCRIPTION
Since cmake 3.23.0, will install lib to /usr/local/lib/x86_64-linux-gnu/ on Debian/Ubuntu by default, so fix this issue.
