### PR TITLE
remove extra libs from AppImage

### DIFF
--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -398,7 +398,10 @@ exclude_libs=(
   libgdk-3.so.0
   libgdk_pixbuf-2.0.so.0
   libgdk-x11-2.0.so.0
+  libgio-2.0.so.0
+  libglib-2.0.so.0
   libgmodule-2.0.so.0
+  libgobject-2.0.so.0
   libgraphite2.so.3
   libgtk-3.so.0
   libgtk-x11-2.0.so.0


### PR DESCRIPTION
This will fix 

```
QApplication: invalid style override 'qt6gtk2' passed, ignoring it.
	Available styles: qt5gtk2, qt6gtk2, gtk2, Windows, Fusion
```

In archlinux or manjaro, and core dump in deepin and ubuntu.

Please upload `qBittorrent-Enhanced-Edition-x86_64.AppImage` and `qBittorrent-Enhanced-Edition-x86_64.AppImage.zsync` to Release page after github action success manually.