### PR TITLE
ci: 🎡 fix build and release

### DIFF
--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -225,18 +225,19 @@ cat config.summary
 cmake --build . --parallel
 cmake --install .
 
+# Remove qt-wayland until next release: https://bugreports.qt.io/browse/QTBUG-104318
 # qt-wayland
-if [ ! -f "/usr/src/qtwayland-${qt_ver}/.unpack_ok" ]; then
-  qtwayland_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtwayland-everywhere-src-${qt_ver}.tar.xz"
-  retry curl -kSL --compressed "${qtwayland_url}" \| tar Jxf - -C "/usr/src/qtwayland-${qt_ver}" --strip-components 1
-  touch "/usr/src/qtwayland-${qt_ver}/.unpack_ok"
-fi
-cd "/usr/src/qtwayland-${qt_ver}"
-rm -fr CMakeCache.txt
-"${QT_BASE_DIR}/bin/qt-configure-module" .
-cat config.summary
-cmake --build . --parallel
-cmake --install .
+# if [ ! -f "/usr/src/qtwayland-${qt_ver}/.unpack_ok" ]; then
+#   qtwayland_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtwayland-everywhere-src-${qt_ver}.tar.xz"
+#   retry curl -kSL --compressed "${qtwayland_url}" \| tar Jxf - -C "/usr/src/qtwayland-${qt_ver}" --strip-components 1
+#   touch "/usr/src/qtwayland-${qt_ver}/.unpack_ok"
+# fi
+# cd "/usr/src/qtwayland-${qt_ver}"
+# rm -fr CMakeCache.txt
+# "${QT_BASE_DIR}/bin/qt-configure-module" .
+# cat config.summary
+# cmake --build . --parallel
+# cmake --install .
 
 # install qt6gtk2 for better look
 if [ ! -d "/usr/src/qt6gtk2/" ]; then
@@ -371,10 +372,10 @@ extra_plugins=(
   sqldrivers
   styles
   tls
-  wayland-decoration-client
-  wayland-graphics-integration-client
-  wayland-graphics-integration-server
-  wayland-shell-integration
+  # wayland-decoration-client
+  # wayland-graphics-integration-client
+  # wayland-graphics-integration-server
+  # wayland-shell-integration
   xcbglintegrations
 )
 exclude_libs=(
@@ -412,6 +413,9 @@ exclude_libs=(
   libmircore.so.1
   libmirprotobuf.so.3
   libmount.so.1
+  libpango-1.0.so.0
+  libpangocairo-1.0.so.0
+  libpangoft2-1.0.so.0
   libpixman-1.so.0
   libprotobuf-lite.so.9
   libselinux.so.1


### PR DESCRIPTION
fix #409 

- Temporary removal of `qt-wayland` build in AppImage.
- Modify cache policy for `musl.cc`

Known issue: `arm-linux-musleabi` build failed: https://bugreports.qt.io/browse/QTBUG-104316

`qt-wayland` build failed, and fixed in the future release: https://bugreports.qt.io/browse/QTBUG-104318 , and it's not primary module, so temporary removal of `qt-wayland` build.

And it seems `musl.cc` limit github action request rate. So if you got download toolchain timeout error in action, you may have to wait for next day and click re-try all failed jobs, and I've changed cache policy, which will use downloaded toolchain caching more aggressively.

Maybe I should find another prebuilt musl based toolchain better than musl.cc