### PR TITLE
ci: 🎡 change cross_build based docker image

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -45,7 +45,7 @@ jobs:
   # cross compile for some other platforms, like arm, mips, etc.
   cross-compile:
     runs-on: ubuntu-latest
-    container: "ubuntu:20.04"
+    container: "abcfy2/muslcc-toolchain-ubuntu:${{ matrix.cross_host }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross_build.sh
+++ b/.github/workflows/cross_build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 
 # This scrip is for static cross compiling
-# Please run this scrip in docker image: ubuntu:20.04
-# E.g: docker run --rm -v `git rev-parse --show-toplevel`:/build ubuntu:20.04 /build/.github/workflows/cross_build.sh
+# Please run this scrip in docker image: abcfy2/muslcc-toolchain-ubuntu:${CROSS_HOST}
+# E.g: docker run --rm -v `git rev-parse --show-toplevel`:/build abcfy2/muslcc-toolchain-ubuntu:arm-linux-musleabi /build/.github/workflows/cross_build.sh
 # If you need keep store build cache in docker volume, just like:
 #   $ docker volume create qbee-nox-cache
-#   $ docker run --rm -v `git rev-parse --show-toplevel`:/build -v qbee-nox-cache:/var/cache/apt -v qbee-nox-cache:/usr/src ubuntu:20.04 /build/.github/workflows/cross_build.sh
+#   $ docker run --rm -v `git rev-parse --show-toplevel`:/build -v qbee-nox-cache:/var/cache/apt -v qbee-nox-cache:/usr/src abcfy2/muslcc-toolchain-ubuntu:arm-linux-musleabi /build/.github/workflows/cross_build.sh
 # Artifacts will copy to the same directory.
 
 set -o pipefail
@@ -49,8 +49,6 @@ apt install -y \
   python3-lxml \
   python3-pip
 
-# value from: https://musl.cc/ (without -cross or -native)
-export CROSS_HOST="${CROSS_HOST:-arm-linux-musleabi}"
 # use zlib-ng instead of zlib by default
 USE_ZLIB_NG=${USE_ZLIB_NG:-1}
 
@@ -83,7 +81,6 @@ i686-*-mingw*)
   ;;
 esac
 
-export CROSS_ROOT="${CROSS_ROOT:-/cross_root}"
 # strip all compiled files by default
 export CFLAGS='-s'
 export CXXFLAGS='-s'
@@ -104,12 +101,10 @@ case "${TARGET_HOST}" in
   ;;
 esac
 
-export PATH="${CROSS_ROOT}/bin:${PATH}"
-export CROSS_PREFIX="${CROSS_ROOT}/${CROSS_HOST}"
 export PKG_CONFIG_PATH="${CROSS_PREFIX}/opt/qt/lib/pkgconfig:${CROSS_PREFIX}/lib/pkgconfig:${CROSS_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
 SELF_DIR="$(dirname "$(readlink -f "${0}")")"
 
-mkdir -p "${CROSS_ROOT}" "/usr/src"
+mkdir -p "/usr/src"
 
 retry() {
   # max retry 5 times
@@ -167,41 +162,6 @@ prepare_ninja() {
     unzip -d /usr/local/bin "/usr/src/ninja-${ninja_ver}-linux.zip"
   fi
   echo "Ninja version $(ninja --version)"
-}
-
-prepare_toolchain() {
-  if [ -f "/usr/src/${CROSS_HOST}-cross.tgz" ]; then
-    cd /usr/src/
-    cached_file_ts="$(stat -c '%Y' "/usr/src/${CROSS_HOST}-cross.tgz")"
-    current_ts="$(date +%s)"
-    if [ "$((${current_ts} - "${cached_file_ts}"))" -gt 2592000 ]; then
-      SHA512SUMS="$(retry curl -ksSL --compressed https://musl.cc/SHA512SUMS)"
-      if echo "${SHA512SUMS}" | grep "${CROSS_HOST}-cross.tgz" | head -1 | sha512sum -c; then
-        touch "/usr/src/${CROSS_HOST}-cross.tgz"
-      else
-        rm -f "/usr/src/${CROSS_HOST}-cross.tgz"
-      fi
-    fi
-  fi
-
-  if [ ! -f "/usr/src/${CROSS_HOST}-cross.tgz" ]; then
-    retry curl -kLC- -o "/usr/src/${CROSS_HOST}-cross.tgz" "https://musl.cc/${CROSS_HOST}-cross.tgz"
-  fi
-  tar -zxf "/usr/src/${CROSS_HOST}-cross.tgz" --transform='s|^\./||S' --strip-components=1 -C "${CROSS_ROOT}"
-  # mingw does not contains posix thread support: https://github.com/meganz/mingw-std-threads
-  # libtorrent need this feature, see issue: https://github.com/arvidn/libtorrent/issues/5330
-  if [ x"${TARGET_HOST}" = xWindows ]; then
-    if [ ! -d "/usr/src/mingw-std-threads" ]; then
-      mingw_std_threads_git_url="https://github.com/meganz/mingw-std-threads.git"
-      if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-        mingw_std_threads_git_url="https://ghproxy.com/${mingw_std_threads_git_url}"
-      fi
-      git clone --depth 1 "${mingw_std_threads_git_url}" "/usr/src/mingw-std-threads"
-    fi
-    cd "/usr/src/mingw-std-threads"
-    git pull
-    cp -fv /usr/src/mingw-std-threads/*.h "${CROSS_PREFIX}/include"
-  fi
 }
 
 prepare_zlib() {
@@ -427,7 +387,6 @@ build_qbittorrent() {
 
 prepare_cmake
 prepare_ninja
-prepare_toolchain
 prepare_zlib
 prepare_ssl
 prepare_boost


### PR DESCRIPTION
Since musl.cc limit github action access. So I create a Ubuntu based docker image https://hub.docker.com/r/abcfy2/muslcc-toolchain-ubuntu to resolve this issue.