### PR TITLE
Update README@Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Chocolatey (Maintainer: [iYato](https://github.com/iYato))
 choco install qbittorrent-enhanced
 ```
 
-Scoop (Maintainer: [Chawye Hsu](https://github.com/chawyehsu))
+Scoop
 
 ```
-scoop bucket add dorado https://github.com/chawyehsu/dorado
+scoop bucket add extras
 scoop install qbittorrent-enhanced
 ```
 


### PR DESCRIPTION
Scoop 官方的 extras bucket 已加入 qBittorrent-Enhanced-Edition ，同时 dorado 的  bucket 也早就移除了

BTW，作为 Scoop 用户希望 Release 里的 *.exe  命名更有规律（qt的大小写、是否有x64，以及顺序），因为 Scoop  的 auto-update 中似乎只有版本号（version）基于正则，URL 不太行，也因此这个包更新常常需要手动更新