### PR TITLE
limit uploaded size to downloaded torrent size for every peer

### DIFF
--- a/src/base/bittorrent/peer_blacklist.hpp
+++ b/src/base/bittorrent/peer_blacklist.hpp
@@ -10,6 +10,7 @@
 
 #include "peer_filter_plugin.hpp"
 #include "peer_logger.hpp"
+#include "peer_plugins_compat.hpp"
 
 // bad peer filter
 bool is_bad_peer(const lt::peer_info& info)
@@ -80,22 +81,22 @@ std::shared_ptr<lt::torrent_plugin> create_peer_action_plugin(
 
 // plugins factory functions
 
-std::shared_ptr<lt::torrent_plugin> create_drop_bad_peers_plugin(lt::torrent_handle const& th, client_data)
+std::shared_ptr<lt::torrent_plugin> create_drop_bad_peers_plugin(lt::torrent_handle const& th, lt::client_data_t)
 {
   return create_peer_action_plugin(th, wrap_filter(is_bad_peer, "bad peer"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_unknown_peers_plugin(lt::torrent_handle const& th, client_data)
+std::shared_ptr<lt::torrent_plugin> create_drop_unknown_peers_plugin(lt::torrent_handle const& th, lt::client_data_t)
 {
   return create_peer_action_plugin(th, wrap_filter(is_unknown_peer, "unknown peer"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_offline_downloader_plugin(lt::torrent_handle const& th, client_data)
+std::shared_ptr<lt::torrent_plugin> create_drop_offline_downloader_plugin(lt::torrent_handle const& th, lt::client_data_t)
 {
   return create_peer_action_plugin(th, wrap_filter(is_offline_downloader, "offline downloader"), drop_connection);
 }
 
-std::shared_ptr<lt::torrent_plugin> create_drop_bittorrent_media_player_plugin(lt::torrent_handle const& th, client_data)
+std::shared_ptr<lt::torrent_plugin> create_drop_bittorrent_media_player_plugin(lt::torrent_handle const& th, lt::client_data_t)
 {
   return create_peer_action_plugin(th, wrap_filter(is_bittorrent_media_player, "bittorrent media player"), drop_connection);
 }

--- a/src/base/bittorrent/peer_filter_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_plugin.hpp
@@ -3,12 +3,6 @@
 #include <libtorrent/extensions.hpp>
 #include <libtorrent/peer_connection_handle.hpp>
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-using client_data = lt::client_data_t;
-#else
-using client_data = void*;
-#endif
-
 using filter_function = std::function<bool(const lt::peer_info&, bool, bool*)>;
 using action_function = std::function<void(lt::peer_connection_handle)>;
 

--- a/src/base/bittorrent/peer_filter_session_plugin.hpp
+++ b/src/base/bittorrent/peer_filter_session_plugin.hpp
@@ -7,6 +7,7 @@
 #include "base/path.h"
 
 #include "peer_filter_plugin.hpp"
+#include "peer_plugins_compat.hpp"
 #include "peer_filter.hpp"
 #include "peer_logger.hpp"
 
@@ -51,7 +52,7 @@ public:
   {
   }
 
-  std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle& th, client_data) override
+  std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle& th, lt::client_data_t) override
   {
     // do not waste CPU and memory for useless objects when no filters are enabled
     if (!m_blacklist && !m_whitelist)

--- a/src/base/bittorrent/peer_plugins_compat.hpp
+++ b/src/base/bittorrent/peer_plugins_compat.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <libtorrent/version.hpp>
+
+#if (LIBTORRENT_VERSION_NUM < 20000)
+namespace libtorrent {
+using client_data_t = void*;
+}
+#endif

--- a/src/base/bittorrent/peer_upload_limit_plugin.hpp
+++ b/src/base/bittorrent/peer_upload_limit_plugin.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <libtorrent/extensions.hpp>
+
+#include <libtorrent/ip_filter.hpp>
+
+#include <libtorrent/peer_connection_handle.hpp>
+#include <libtorrent/peer_info.hpp>
+
+#include <libtorrent/session_handle.hpp>
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/torrent_status.hpp>
+
+#include "peer_logger.hpp"
+#include "peer_plugins_compat.hpp"
+
+class peer_timed_check_plugin final : public lt::peer_plugin
+{
+public:
+  using filter_function_t = std::function<bool(const lt::peer_info&)>;
+  using action_function_t = std::function<void(lt::peer_connection_handle)>;
+
+  peer_timed_check_plugin(lt::peer_connection_handle ph, filter_function_t filter, action_function_t action)
+    : m_connection(std::move(ph))
+    , m_filter(std::move(filter))
+    , m_action(std::move(action))
+  {
+  }
+
+  void tick() override
+  {
+    lt::peer_info info;
+    m_connection.get_peer_info(info);
+
+    if (m_filter(info))
+      m_action(m_connection);
+  }
+
+private:
+  lt::peer_connection_handle m_connection;
+  filter_function_t m_filter;
+  action_function_t m_action;
+};
+
+
+class peer_upload_limit_plugin final : public lt::torrent_plugin
+{
+public:
+  peer_upload_limit_plugin(lt::session_handle sh, lt::torrent_handle th)
+    : m_session(std::move(sh))
+    , m_torrent(std::move(th))
+  {
+  }
+
+  std::shared_ptr<lt::peer_plugin> new_connection(lt::peer_connection_handle const& conn) override
+  {
+    // *INDENT-OFF*
+    return std::make_shared<peer_timed_check_plugin>(conn,
+        [this](auto&& info) { return filter(info); },
+        [this](auto&& conn) { action(conn); });
+    // *INDENT-ON*
+  }
+
+private:
+  bool filter(const lt::peer_info& info)
+  {
+    lt::torrent_status status = m_torrent.status(lt::torrent_handle::query_accurate_download_counters);
+    if (info.total_upload > status.total_wanted_done) {
+      peer_logger_singleton::instance().log_peer(info, "upload limit");
+      // peer is considered suspicious (downloaded too much)
+      // just dropping connection is not enough - it will be able to download after reconnect
+      // so ban its IP (ban should be NOT permanent - only for current session)
+      lt::ip_filter ip_filter = m_session.get_ip_filter();
+      ip_filter.add_rule(info.ip.address(), info.ip.address(), lt::ip_filter::blocked);
+      m_session.set_ip_filter(ip_filter);
+      return true;
+    }
+    return false;
+  }
+
+  void action(lt::peer_connection_handle conn)
+  {
+    conn.disconnect(boost::asio::error::connection_refused, lt::operation_t::bittorrent, lt::disconnect_severity_t{0});
+  }
+
+private:
+  lt::session_handle m_session;
+  lt::torrent_handle m_torrent;
+};
+
+
+class peer_upload_limit_session_plugin final : public lt::plugin
+{
+public:
+  void added(lt::session_handle const& sess) override
+  {
+    m_session = sess;
+  }
+
+  std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle& th, lt::client_data_t) override
+  {
+    // ignore private torrents
+    if (th.torrent_file() && th.torrent_file()->priv())
+      return nullptr;
+
+    return std::make_shared<peer_upload_limit_plugin>(m_session, th);
+  }
+
+private:
+  lt::session_handle m_session;
+};

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -107,6 +107,7 @@
 #include "nativesessionextension.h"
 #include "peer_blacklist.hpp"
 #include "peer_filter_session_plugin.hpp"
+#include "peer_upload_limit_plugin.hpp"
 #include "portforwarderimpl.h"
 #include "resumedatastorage.h"
 #include "torrentimpl.h"
@@ -1564,6 +1565,7 @@ void SessionImpl::initializeNativeSession()
     if (isAutoBanBTPlayerPeerEnabled())
         m_nativeSession->add_extension(&create_drop_bittorrent_media_player_plugin);
     m_nativeSession->add_extension(std::make_shared<peer_filter_session_plugin>());
+    m_nativeSession->add_extension(std::make_shared<peer_upload_limit_session_plugin>());
 
     m_nativeSession->add_extension(std::make_shared<NativeSessionExtension>());
 }


### PR DESCRIPTION
implemented new libtorrent plugin to limit upload size per peer to torrent downloaded size. when peer tries to download more than that size - its address is banned (using libtorrent api) for current session. peer id and reported progress are not taken into account in any way, only amount of data uploaded to the peer.
check is performed about every second (according to libtorrent documentation, and this looks true), it is very lightweight - just compare to integers, so it should not have a significant impact on performance.
another commit included into this pr is just small refactoring - moved libtorrent versions compatibility stuff into its own file, and used it where it is required (not just a ramdom "common" place as it was before).
not well tested, but added check seems not causing any issues with upload, and changing "allowed size" to for example 1 MB or 10 MB drops peers very quickly and they seems not appear anymore (at least until app restart). so, should be fine. but any testing is welcome.
closes #432 