### PR TITLE
Match qt6 installer in Winget Releaser regex, Bump action to `v2`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -13,7 +13,7 @@ jobs:
           $VERSION = "${{ github.event.release.tag_name }}".TrimStart('release-')
           echo "::set-output name=version::$VERSION"
         shell: pwsh
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: c0re100.qBittorrent-Enhanced-Edition
           version: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           identifier: c0re100.qBittorrent-Enhanced-Edition
           version: ${{ steps.get-version.outputs.version }}
-          installers-regex: 'qbittorrent_enhanced_[0-9.]+(_x64)?_setup.exe$'
+          installers-regex: 'qbittorrent_enhanced_[0-9.]+(_qt6_x64)?_setup.exe$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
Winget only supports Windows 10 and above. Therefore, we can preferably add the Qt6 version to Winget instead.

Also, please see this issue: https://github.com/c0re100/qBittorrent-Enhanced-Edition/issues/445.