### PR TITLE
NSIS: Uncheck PDB install by default

### DIFF
--- a/dist/windows/installer.nsi
+++ b/dist/windows/installer.nsi
@@ -63,8 +63,7 @@ Section $(inst_qbt_req) ;"qBittorrent (required)"
 
 SectionEnd
 
-; Optional section (can be disabled by the user)
-Section "Install with Debug Symbol File"
+Section /o "Install with Debug Symbol File"
 
   ; Set output path to the installation directory.
   SetOutPath $INSTDIR


### PR DESCRIPTION
Save 230MB (87%!) of space by default for most users who don't need debug information.

Otherwise, qBittorrent builds are pretty slim, actually!