### PR TITLE
fix appimage build

### DIFF
--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -239,7 +239,7 @@ prepare_qt() {
   fi
   cd "/usr/src/qttools-${qt_ver}"
   rm -fr CMakeCache.txt
-  "${QT_BASE_DIR}/bin/qt-configure-module" . -no-feature-designer
+  "${QT_BASE_DIR}/bin/qt-configure-module" .
   cat config.summary
   cmake --build . --parallel
   cmake --install .


### PR DESCRIPTION
It seems qttools 6.5.1 removed option `-no-feature-designer`. So I have to remove this option to fix appimage build.