### PR TITLE
Change Winget runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -4,15 +4,16 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
       - name: Get version
         id: get-version
         run: |
-          # Finding the version from release name
-          $VERSION = "${{ github.event.release.tag_name }}".TrimStart('release-')
-          echo "::set-output name=version::$VERSION"
-        shell: pwsh
+          # Finding the version from release tag
+          version=${RELEASE_TAG#release-}
+          echo "version=$version" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: c0re100.qBittorrent-Enhanced-Edition


### PR DESCRIPTION
<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->

- Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.
- Remove deprecated `set-output` as warned in the action: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/