### PR TITLE
Prevent use shadowban function to leech

### DIFF
--- a/src/base/bittorrent/peer_shadowban_plugin.hpp
+++ b/src/base/bittorrent/peer_shadowban_plugin.hpp
@@ -29,6 +29,16 @@ public:
         return peer_plugin::on_request(r);
     }
 
+    // don't send request if peer shadowbanned to prevent use this function to leech
+    bool write_request(lt::peer_request const &r) override
+    {
+        if (is_shadowbanned_peer())
+        {
+            return true;
+        }
+        return peer_plugin::write_request(r);
+    }
+
 protected:
     bool is_shadowbanned_peer()
     {


### PR DESCRIPTION
Do not request data when the peer is shadowbanned to avoid using the shadowban function to leech
在对等体被shadowban时不应请求数据以避免使用shadowban功能吸血