### PR TITLE
fix AppImage not working on Fedora

### DIFF
--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -373,6 +373,11 @@ export XDG_DATA_DIRS="\${this_dir}/usr/share:\${XDG_DATA_DIRS}:/usr/share:/usr/l
 export QT_QPA_PLATFORMTHEMES=gtk2
 export QT_STYLE_OVERRIDE=qt6gtk2
 
+# Force set openssl config directory to an invalid directory to fallback to use default openssl config.
+# This can avoid some distributions (mainly Fedora) having some strange patches or configurations
+# for openssl that make the libssl in Appimage bundle unavailable.
+export OPENSSL_CONF="\${this_dir}"
+
 # Find the system certificates location
 # https://gitlab.com/probono/platformissues/blob/master/README.md#certificates
 possible_locations=(


### PR DESCRIPTION
RedHat add some openssl patches which not compatible with official openssl. This will cause third party compiled openssl failed Fedora.

So force set `OPENSSL_CONF` to an invalid directory to force libssl fallback to use the default settings to back to normal.
