### PR TITLE
🐛 webui: Fix bug of cookie cannot set expiration

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -741,6 +741,7 @@ void WebApplication::sessionStart()
     cookie.setHttpOnly(true);
     cookie.setSecure(m_isSecureCookieEnabled && m_isHttpsEnabled);
     cookie.setPath(u"/"_s);
+    cookie.setExpirationDate(QDateTime::currentDateTime().addSecs(m_sessionTimeout));
     if (m_isCSRFProtectionEnabled)
         cookie.setSameSitePolicy(QNetworkCookie::SameSite::Strict);
     else if (cookie.isSecure())


### PR DESCRIPTION
Fix issue that expiration of cookie (SID) is not correctly set, resulting in logging in status cannot be **remembered**
Expiration using settings -> WebUI -> Session timeout