### PR TITLE
readme: scoop installation via extras bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Chocolatey (Maintainer: [iYato](https://github.com/iYato))
 choco install qbittorrent-enhanced
 ```
 
-Scoop (Maintainer: [Chawye Hsu](https://github.com/chawyehsu))
+Scoop
 
 ```
-scoop bucket add dorado https://github.com/chawyehsu/dorado
+scoop bucket add extras
 scoop install qbittorrent-enhanced
 ```
 


### PR DESCRIPTION
Closes #550

App already provided by the extras bucket ([scoop official bucket](https://github.com/ScoopInstaller/Scoop?tab=readme-ov-file#known-application-buckets))