### PR TITLE
fix github actions build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -13,24 +13,32 @@ on:
 
 jobs:
   appimage:
-    runs-on: ubuntu-latest
-    container: "ubuntu:20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    container: "ubuntu:22.04"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             /usr/src/
             /var/cache/apt/
-          key: appimage-build-dependencies-cache-${{ github.sha }}
+          key: appimage-build-dependencies-cache-${{ matrix.arch }}-${{ github.sha }}
           restore-keys: |
-            appimage-build-dependencies-cache-
+            appimage-build-dependencies-cache-${{ matrix.arch }}-
       - name: Build AppImage
         run: .github/workflows/build_appimage.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: qBittorrent-Enhanced-Edition-x86_64.AppImage
+          name: qBittorrent-Enhanced-Edition-${{ matrix.arch }}.AppImage
           path: ".github/workflows/qBittorrent-Enhanced-Edition*.AppImage*"
       - name: Upload Github Assets
         if: startsWith(github.ref, 'refs/tags/')
@@ -45,26 +53,27 @@ jobs:
   # cross compile for some other platforms, like arm, mips, etc.
   cross-compile:
     runs-on: ubuntu-latest
-    container: "abcfy2/muslcc-toolchain-ubuntu:${{ matrix.cross_host }}"
+    container: "ghcr.io/abcfy2/musl-cross-toolchain-ubuntu:${{ matrix.cross_host }}"
     strategy:
       fail-fast: false
       matrix:
         cross_host:
-          # cross toolchain downloads from: https://musl.cc/
-          # you need to find the name ${cross_host}-cross.tgz
-          - arm-linux-musleabi
-          - arm-linux-musleabihf
-          - aarch64-linux-musl
-          - mips-linux-musl
-          - mipsel-linux-musl
-          - mips64-linux-musl
-          - mips64el-linux-musl
-          - x86_64-linux-musl
-          - i686-linux-musl
+          # cross toolchain downloads from: https://github.com/cross-tools/musl-cross
+          # you need to find the name in **Supported targets**
+          - armv7-unknown-linux-musleabihf
+          - aarch64-unknown-linux-musl
+          # Remove mips32 series because qt 6.11.0 will build failed
+          # - mips-unknown-linux-musl
+          # - mipsel-unknown-linux-musl
+          - mips64-unknown-linux-musl
+          - mips64el-unknown-linux-musl
+          - x86_64-unknown-linux-musl
+          - i686-unknown-linux-musl
+          - loongarch64-unknown-linux-musl
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             /usr/src/
@@ -72,13 +81,18 @@ jobs:
           key: cross-build-dependencies-cache-${{ matrix.cross_host }}-${{ github.sha }}
           restore-keys: |
             cross-build-dependencies-cache-${{ matrix.cross_host }}-
+      - name: Set archive host name
+        shell: bash
+        run: echo "ARCHIVE_HOST=${CROSS_HOST//-unknown/}" >> "$GITHUB_ENV"
+        env:
+          CROSS_HOST: "${{ matrix.cross_host }}"
       - name: cross compile nox-static
         env:
           CROSS_HOST: "${{ matrix.cross_host }}"
         run: .github/workflows/cross_build.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: qbittorrent-enhanced-nox_${{ matrix.cross_host }}_static
+          name: qbittorrent-enhanced-nox_${{ env.ARCHIVE_HOST }}_static
           path: |
             /tmp/qbittorrent-nox*
       - name: Upload Github Assets
@@ -86,6 +100,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ".github/workflows/qbittorrent-enhanced-nox_${{ matrix.cross_host }}_static.zip"
+          file: ".github/workflows/qbittorrent-enhanced-nox_${{ env.ARCHIVE_HOST }}_static.zip"
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/build_appimage.sh
+++ b/.github/workflows/build_appimage.sh
@@ -2,10 +2,10 @@
 
 # This script is for building AppImage
 # Please run this script in docker image: ubuntu:20.04
-# E.g: docker run --rm -v `git rev-parse --show-toplevel`:/build ubuntu:20.04 /build/.github/workflows/build_appimage.sh
+# E.g: docker run --rm -v "$(git rev-parse --show-toplevel):/build" ubuntu:20.04 /build/.github/workflows/build_appimage.sh
 # If you need keep store build cache in docker volume, just like:
 #   $ docker volume create qbee-cache
-#   $ docker run --rm -v `git rev-parse --show-toplevel`:/build -v qbee-cache:/var/cache/apt -v qbee-cache:/usr/src ubuntu:20.04 /build/.github/workflows/build_appimage.sh
+#   $ docker run --rm -v "$(git rev-parse --show-toplevel):/build" -v qbee-cache:/var/cache/apt -v qbee-cache:/usr/src ubuntu:20.04 /build/.github/workflows/build_appimage.sh
 # Artifacts will copy to the same directory.
 
 set -o pipefail
@@ -16,6 +16,7 @@ export LIBTORRENT_BRANCH="RC_1_2"
 export LC_ALL="C.UTF-8"
 export DEBIAN_FRONTEND=noninteractive
 export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
+export ARCH="$(uname -m)"
 SELF_DIR="$(dirname "$(readlink -f "${0}")")"
 
 retry() {
@@ -49,13 +50,11 @@ prepare_baseenv() {
   rm -f /etc/apt/sources.list.d/*.list*
   # Ubuntu mirror for local building
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    source /etc/os-release
-    cat >/etc/apt/sources.list <<EOF
-deb http://repo.huaweicloud.com/ubuntu/ ${UBUNTU_CODENAME} main restricted universe multiverse
-deb http://repo.huaweicloud.com/ubuntu/ ${UBUNTU_CODENAME}-updates main restricted universe multiverse
-deb http://repo.huaweicloud.com/ubuntu/ ${UBUNTU_CODENAME}-backports main restricted universe multiverse
-deb http://repo.huaweicloud.com/ubuntu/ ${UBUNTU_CODENAME}-security main restricted universe multiverse
-EOF
+    sed -i \
+      -e 's|http://archive.ubuntu.com/ubuntu/|http://repo.huaweicloud.com/ubuntu/|g' \
+      -e 's|http://security.ubuntu.com/ubuntu/|http://repo.huaweicloud.com/ubuntu/|g' \
+      -e 's|http://ports.ubuntu.com/ubuntu-ports/|http://repo.huaweicloud.com/ubuntu-ports/|g' \
+      /etc/apt/sources.list
     export PIP_INDEX_URL="https://repo.huaweicloud.com/repository/pypi/simple"
   fi
 
@@ -65,24 +64,16 @@ EOF
   echo -e 'Acquire::https::Verify-Peer "false";\nAcquire::https::Verify-Host "false";' >/etc/apt/apt.conf.d/99-trust-https
 
   # Since cmake 3.23.0 CMAKE_INSTALL_LIBDIR will force set to lib/<multiarch-tuple> on Debian
-  echo '/usr/local/lib/x86_64-linux-gnu' >/etc/ld.so.conf.d/x86_64-linux-gnu-local.conf
+  echo "/usr/local/lib/${ARCH}-linux-gnu" >/etc/ld.so.conf.d/${ARCH}-linux-gnu-local.conf
   echo '/usr/local/lib64' >/etc/ld.so.conf.d/lib64-local.conf
-
-  retry apt update
-  retry apt install -y software-properties-common apt-transport-https
-  # retry apt-add-repository -yn ppa:savoury1/backports
-  retry apt-add-repository -yn ppa:savoury1/gcc-11
-
-  if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    sed -i 's@http://ppa.launchpad.net@https://launchpad.proxy.ustclug.org@' /etc/apt/sources.list.d/*.list
-  fi
 
   retry apt update
   retry apt install -y \
     build-essential \
     curl \
+    make \
+    file \
     desktop-file-utils \
-    g++-11 \
     git \
     libbrotli-dev \
     libfontconfig1-dev \
@@ -120,16 +111,13 @@ EOF
     libzstd-dev \
     pkg-config \
     unzip \
+    xz-utils \
     zlib1g-dev \
     zsync
 
-  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
-  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
-
   apt autoremove --purge -y
   # strip all compiled files by default
-  export CFLAGS='-s'
-  export CXXFLAGS='-s'
+  export LDFLAGS='-Wl,-s'
   # Force refresh ld.so.cache
   ldconfig
 }
@@ -138,37 +126,42 @@ prepare_buildenv() {
   # install cmake and ninja-build
   if ! which cmake &>/dev/null; then
     cmake_latest_ver="$(retry curl -ksSL --compressed https://cmake.org/download/ \| grep "'Latest Release'" \| sed -r "'s/.*Latest Release\s*\((.+)\).*/\1/'" \| head -1)"
-    cmake_binary_url="https://github.com/Kitware/CMake/releases/download/v${cmake_latest_ver}/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz"
+    cmake_binary_url="https://github.com/Kitware/CMake/releases/download/v${cmake_latest_ver}/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz"
     cmake_sha256_url="https://github.com/Kitware/CMake/releases/download/v${cmake_latest_ver}/cmake-${cmake_latest_ver}-SHA-256.txt"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      cmake_binary_url="https://ghp.ci/${cmake_binary_url}"
-      cmake_sha256_url="https://ghp.ci/${cmake_sha256_url}"
+      cmake_binary_url="https://gh-proxy.com/${cmake_binary_url}"
+      cmake_sha256_url="https://gh-proxy.com/${cmake_sha256_url}"
     fi
-    if [ -f "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz" ]; then
+    if [ -f "/usr/src/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz" ]; then
       cd /usr/src
-      cmake_sha256="$(retry curl -ksSL --compressed "${cmake_sha256_url}" \| grep "cmake-${cmake_latest_ver}-linux-x86_64.tar.gz")"
+      cmake_sha256="$(retry curl -ksSL --compressed "${cmake_sha256_url}" \| grep "cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz")"
       if ! echo "${cmake_sha256}" | sha256sum -c; then
-        rm -f "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz"
+        rm -f "/usr/src/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz"
       fi
     fi
-    if [ ! -f "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz" ]; then
-      retry curl -kLo "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz" "${cmake_binary_url}"
+    if [ ! -f "/usr/src/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz" ]; then
+      retry curl -kLo "/usr/src/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz" "${cmake_binary_url}"
     fi
-    tar -zxf "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz" -C /usr/local --strip-components 1
+    tar -zxf "/usr/src/cmake-${cmake_latest_ver}-linux-${ARCH}.tar.gz" -C /usr/local --strip-components 1
   fi
   cmake --version
   if ! which ninja &>/dev/null; then
     ninja_ver="$(retry curl -ksSL --compressed https://ninja-build.org/ \| grep "'The last Ninja release is'" \| sed -r "'s@.*<b>(.+)</b>.*@\1@'" \| head -1)"
-    ninja_binary_url="https://github.com/ninja-build/ninja/releases/download/${ninja_ver}/ninja-linux.zip"
+    ninja_arch_suffix=""
+    if [ "${ARCH}" != "x86_64" ]; then
+      ninja_arch_suffix="-${ARCH}"
+    fi
+    ninja_local_name="ninja-${ninja_ver}-linux${ninja_arch_suffix}"
+    ninja_binary_url="https://github.com/ninja-build/ninja/releases/download/${ninja_ver}/ninja-linux${ninja_arch_suffix}.zip"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      ninja_binary_url="https://ghp.ci/${ninja_binary_url}"
+      ninja_binary_url="https://gh-proxy.com/${ninja_binary_url}"
     fi
-    if [ ! -f "/usr/src/ninja-${ninja_ver}-linux.zip.download_ok" ]; then
-      rm -f "/usr/src/ninja-${ninja_ver}-linux.zip"
-      retry curl -kLC- -o "/usr/src/ninja-${ninja_ver}-linux.zip" "${ninja_binary_url}"
-      touch "/usr/src/ninja-${ninja_ver}-linux.zip.download_ok"
+    if [ ! -f "/usr/src/${ninja_local_name}.zip.download_ok" ]; then
+      rm -f "/usr/src/${ninja_local_name}.zip"
+      retry curl -kLC- -o "/usr/src/${ninja_local_name}.zip" "${ninja_binary_url}"
+      touch "/usr/src/${ninja_local_name}.zip.download_ok"
     fi
-    unzip -d /usr/local/bin "/usr/src/ninja-${ninja_ver}-linux.zip"
+    unzip -d /usr/local/bin "/usr/src/${ninja_local_name}.zip"
   fi
   echo "Ninja version $(ninja --version)"
 }
@@ -179,7 +172,7 @@ prepare_ssl() {
   echo "openssl version: ${openssl_ver}"
   openssl_latest_url="https://github.com/openssl/openssl/archive/refs/tags/${openssl_filename}"
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    openssl_latest_url="https://ghp.ci/${openssl_latest_url}"
+    openssl_latest_url="https://gh-proxy.com/${openssl_latest_url}"
   fi
   mkdir -p "/usr/src/openssl-${openssl_ver}/"
   if [ ! -f "/usr/src/openssl-${openssl_ver}/.unpack_ok" ]; then
@@ -195,15 +188,19 @@ prepare_ssl() {
 
 prepare_qt() {
   # install qt
-  qt_major_ver="$(retry curl -ksSL --compressed https://download.qt.io/official_releases/qt/ \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
-  qt_ver="$(retry curl -ksSL --compressed https://download.qt.io/official_releases/qt/${qt_major_ver}/ \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
+  QT_DOWNLOAD_URL_BASE="https://download.qt.io"
+  if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
+      QT_DOWNLOAD_URL_BASE="https://mirrors.sjtug.sjtu.edu.cn/qt"
+  fi
+  qt_major_ver="$(retry curl -ksSL --compressed "https://download.qt.io/official_releases/qt/" \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
+  qt_ver="$(retry curl -ksSL --compressed "https://download.qt.io/official_releases/qt/${qt_major_ver}/" \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
   echo "Using qt version: ${qt_ver}"
   mkdir -p "/usr/src/qtbase-${qt_ver}" \
     "/usr/src/qttools-${qt_ver}" \
     "/usr/src/qtsvg-${qt_ver}" \
     "/usr/src/qtwayland-${qt_ver}"
   if [ ! -f "/usr/src/qtbase-${qt_ver}/.unpack_ok" ]; then
-    qtbase_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtbase-everywhere-src-${qt_ver}.tar.xz"
+    qtbase_url="${QT_DOWNLOAD_URL_BASE}/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtbase-everywhere-src-${qt_ver}.tar.xz"
     retry curl -kSL --compressed "${qtbase_url}" \| tar Jxf - -C "/usr/src/qtbase-${qt_ver}" --strip-components 1
     touch "/usr/src/qtbase-${qt_ver}/.unpack_ok"
   fi
@@ -232,7 +229,7 @@ prepare_qt() {
   export LD_LIBRARY_PATH="${QT_BASE_DIR}/lib:${LD_LIBRARY_PATH}"
   export PATH="${QT_BASE_DIR}/bin:${PATH}"
   if [ ! -f "/usr/src/qtsvg-${qt_ver}/.unpack_ok" ]; then
-    qtsvg_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtsvg-everywhere-src-${qt_ver}.tar.xz"
+    qtsvg_url="${QT_DOWNLOAD_URL_BASE}/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtsvg-everywhere-src-${qt_ver}.tar.xz"
     retry curl -kSL --compressed "${qtsvg_url}" \| tar Jxf - -C "/usr/src/qtsvg-${qt_ver}" --strip-components 1
     touch "/usr/src/qtsvg-${qt_ver}/.unpack_ok"
   fi
@@ -242,7 +239,7 @@ prepare_qt() {
   cmake --build . --parallel
   cmake --install .
   if [ ! -f "/usr/src/qttools-${qt_ver}/.unpack_ok" ]; then
-    qttools_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qttools-everywhere-src-${qt_ver}.tar.xz"
+    qttools_url="${QT_DOWNLOAD_URL_BASE}/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qttools-everywhere-src-${qt_ver}.tar.xz"
     retry curl -kSL --compressed "${qttools_url}" \| tar Jxf - -C "/usr/src/qttools-${qt_ver}" --strip-components 1
     touch "/usr/src/qttools-${qt_ver}/.unpack_ok"
   fi
@@ -253,10 +250,9 @@ prepare_qt() {
   cmake --build . --parallel
   cmake --install .
 
-  # Remove qt-wayland until next release: https://bugreports.qt.io/browse/QTBUG-104318
   # qt-wayland
   if [ ! -f "/usr/src/qtwayland-${qt_ver}/.unpack_ok" ]; then
-    qtwayland_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtwayland-everywhere-src-${qt_ver}.tar.xz"
+    qtwayland_url="${QT_DOWNLOAD_URL_BASE}/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtwayland-everywhere-src-${qt_ver}.tar.xz"
     retry curl -kSL --compressed "${qtwayland_url}" \| tar Jxf - -C "/usr/src/qtwayland-${qt_ver}" --strip-components 1
     touch "/usr/src/qtwayland-${qt_ver}/.unpack_ok"
   fi
@@ -269,26 +265,17 @@ prepare_qt() {
 }
 
 preapare_libboost() {
-  # build latest boost
-  # boost_ver="$(retry curl -ksSfL --compressed https://www.boost.org/users/download/ \| grep "'>Version\s*'" \| sed -r "'s/.*Version\s*([^<]+).*/\1/'" \| head -1)"
+  # Boost >= 1.69: boost::system is header-only.
+  # libtorrent only links Boost::headers (see CMakeLists.txt).
   boost_ver="1.86.0"
   echo "boost version ${boost_ver}"
-  mkdir -p "/usr/src/boost-${boost_ver}"
   if [ ! -f "/usr/src/boost-${boost_ver}/.unpack_ok" ]; then
     boost_latest_url="https://sourceforge.net/projects/boost/files/boost/${boost_ver}/boost_${boost_ver//./_}.tar.bz2/download"
+    mkdir -p "/usr/src/boost-${boost_ver}"
     retry curl -kSL "${boost_latest_url}" \| tar -jxf - -C "/usr/src/boost-${boost_ver}" --strip-components 1
     touch "/usr/src/boost-${boost_ver}/.unpack_ok"
   fi
-  cd "/usr/src/boost-${boost_ver}"
-  if [ ! -f ./b2 ]; then
-    ./bootstrap.sh
-  fi
-  ./b2 -d0 -q install --with-system variant=release link=shared runtime-link=shared
-  cd "/usr/src/boost-${boost_ver}/tools/build"
-  if [ ! -f ./b2 ]; then
-    ./bootstrap.sh
-  fi
-  ./b2 -d0 -q install variant=release link=shared runtime-link=shared
+  cp -rf "/usr/src/boost-${boost_ver}/boost" /usr/local/include/
 }
 
 prepare_libtorrent() {
@@ -296,7 +283,7 @@ prepare_libtorrent() {
   echo "libtorrent-rasterbar branch: ${LIBTORRENT_BRANCH}"
   libtorrent_git_url="https://github.com/arvidn/libtorrent.git"
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    libtorrent_git_url="https://ghp.ci/${libtorrent_git_url}"
+    libtorrent_git_url="https://gh-proxy.com/${libtorrent_git_url}"
   fi
   if [ ! -d "/usr/src/libtorrent-rasterbar-${LIBTORRENT_BRANCH}/" ]; then
     retry git clone --depth 1 --recursive --shallow-submodules --branch "${LIBTORRENT_BRANCH}" \
@@ -317,8 +304,7 @@ prepare_libtorrent() {
   cmake \
     -B build \
     -G "Ninja" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_STANDARD=17
+    -DCMAKE_BUILD_TYPE=Release
   cmake --build build
   cmake --install build
   # force refresh ld.so.cache
@@ -334,7 +320,6 @@ build_qbee() {
     -G "Ninja" \
     -DCMAKE_PREFIX_PATH="${QT_BASE_DIR}/lib/cmake/" \
     -DCMAKE_BUILD_TYPE="Release" \
-    -DCMAKE_CXX_STANDARD="17" \
     -DCMAKE_INSTALL_PREFIX="/tmp/qbee/AppDir/usr"
   cmake --build build
   rm -fr /tmp/qbee/
@@ -343,12 +328,12 @@ build_qbee() {
 
 build_appimage() {
   # build AppImage
-  linuxdeploy_qt_download_url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  linuxdeploy_qt_download_url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-${ARCH}.AppImage"
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    linuxdeploy_qt_download_url="https://ghp.ci/${linuxdeploy_qt_download_url}"
+    linuxdeploy_qt_download_url="https://gh-proxy.com/${linuxdeploy_qt_download_url}"
   fi
-  [ -x "/tmp/linuxdeployqt-continuous-x86_64.AppImage" ] || retry curl -kSLC- -o /tmp/linuxdeployqt-continuous-x86_64.AppImage "${linuxdeploy_qt_download_url}"
-  chmod -v +x '/tmp/linuxdeployqt-continuous-x86_64.AppImage'
+  [ -x "/tmp/linuxdeployqt-continuous-${ARCH}.AppImage" ] || retry curl -kSLC- -o /tmp/linuxdeployqt-continuous-${ARCH}.AppImage "${linuxdeploy_qt_download_url}"
+  chmod -v +x "/tmp/linuxdeployqt-continuous-${ARCH}.AppImage"
   cd "/tmp/qbee"
   ln -svf usr/share/icons/hicolor/scalable/apps/qbittorrent.svg /tmp/qbee/AppDir/
   ln -svf qbittorrent.svg /tmp/qbee/AppDir/.DirIcon
@@ -414,6 +399,7 @@ EOF
     libbsd.so.0
     libcairo-gobject.so.2
     libcairo.so.2
+    libcap.so.2
     libcapnp-0.5.3.so
     libcapnp-0.6.1.so
     libdatrie.so.1
@@ -439,6 +425,7 @@ EOF
     libmircommon.so.7
     libmircore.so.1
     libmirprotobuf.so.3
+    libmd.so.0
     libmount.so.1
     libpango-1.0.so.0
     libpangocairo-1.0.so.0
@@ -488,7 +475,7 @@ EOF
   sed -i 's/Name=qBittorrent.*/Name=qBittorrent-Enhanced-Edition/;/SingleMainWindow/d' /tmp/qbee/AppDir/usr/share/applications/*.desktop
 
   export APPIMAGE_EXTRACT_AND_RUN=1
-  /tmp/linuxdeployqt-continuous-x86_64.AppImage \
+  /tmp/linuxdeployqt-continuous-${ARCH}.AppImage \
     /tmp/qbee/AppDir/usr/share/applications/*.desktop \
     -always-overwrite \
     -bundle-non-qt-libs \
@@ -497,10 +484,9 @@ EOF
     -exclude-libs="$(join_by ',' "${exclude_libs[@]}")"
 
   # Workaround to use the static runtime with the appimage
-  ARCH="$(arch)"
   appimagetool_download_url="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    appimagetool_download_url="https://ghp.ci/${appimagetool_download_url}"
+    appimagetool_download_url="https://gh-proxy.com/${appimagetool_download_url}"
   fi
   [ -x "/tmp/appimagetool-${ARCH}.AppImage" ] || retry curl -kSLC- -o /tmp/appimagetool-"${ARCH}".AppImage "${appimagetool_download_url}"
   chmod -v +x "/tmp/appimagetool-${ARCH}.AppImage"

--- a/.github/workflows/cross_build.sh
+++ b/.github/workflows/cross_build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 
 # This script is for static cross compiling
-# Please run this script in docker image: abcfy2/muslcc-toolchain-ubuntu:${CROSS_HOST}
-# E.g: docker run --rm -v `git rev-parse --show-toplevel`:/build abcfy2/muslcc-toolchain-ubuntu:arm-linux-musleabi /build/.github/workflows/cross_build.sh
+# Please run this script in docker image: abcfy2/musl-cross-toolchain-ubuntu:${CROSS_HOST}
+# E.g: docker run --rm -v "$(git rev-parse --show-toplevel):/build" abcfy2/musl-cross-toolchain-ubuntu:arm-unknown-linux-musleabi /build/.github/workflows/cross_build.sh
 # If you need keep store build cache in docker volume, just like:
 #   $ docker volume create qbee-nox-cache
-#   $ docker run --rm -v `git rev-parse --show-toplevel`:/build -v qbee-nox-cache:/var/cache/apt -v qbee-nox-cache:/usr/src abcfy2/muslcc-toolchain-ubuntu:arm-linux-musleabi /build/.github/workflows/cross_build.sh
+#   $ docker run --rm -v "$(git rev-parse --show-toplevel):/build" -v qbee-nox-cache:/var/cache/apt -v qbee-nox-cache:/usr/src abcfy2/musl-cross-toolchain-ubuntu:arm-unknown-linux-musleabi /build/.github/workflows/cross_build.sh
 # Artifacts will copy to the same directory.
 
 set -o pipefail
@@ -54,47 +54,48 @@ apt install -y \
   zip \
   pkg-config \
   pipx \
-  python3-pip
+  python3-pip \
+  libglib2.0-0t64
 
 # use zlib-ng instead of zlib by default
 USE_ZLIB_NG=${USE_ZLIB_NG:-1}
 
 # OPENSSL_COMPILER value is from openssl source: ./Configure LIST
-# QT_DEVICE and QT_DEVICE_OPTIONS value are from https://github.com/qt/qtbase/tree/dev/mkspecs/devices/
 case "${CROSS_HOST}" in
-arm-linux*)
+arm*linux*)
   export OPENSSL_COMPILER=linux-armv4
   ;;
-aarch64-linux*)
+aarch64*linux*)
   export OPENSSL_COMPILER=linux-aarch64
   ;;
-mips-linux* | mipsel-linux*)
-  export OPENSSL_COMPILER=linux-mips32
-  ;;
-mips64-linux* | mips64el-linux*)
+mips64el*linux* | mips64*linux*)
   export OPENSSL_COMPILER=linux64-mips64
   ;;
-x86_64-linux*)
+mipsel*linux* | mips*linux*)
+  export OPENSSL_COMPILER=linux-mips32
+  ;;
+loongarch64*linux*)
+  export OPENSSL_COMPILER=linux64-loongarch64
+  ;;
+x86_64*linux*)
   export OPENSSL_COMPILER=linux-x86_64
   ;;
-x86_64-*-mingw*)
+x86_64*mingw*)
   export OPENSSL_COMPILER=mingw64
   ;;
-i686-*-mingw*)
+i686*mingw*)
   export OPENSSL_COMPILER=mingw
   ;;
 *)
-  export OPENSSL_COMPILER=gcc
+  export OPENSSL_COMPILER=cc
   ;;
 esac
 
 # strip all compiled files by default
-export CFLAGS='-s'
-export CXXFLAGS='-s'
+export LDFLAGS='-Wl,-s'
 
 TARGET_ARCH="${CROSS_HOST%%-*}"
-TARGET_HOST="${CROSS_HOST#*-}"
-case "${TARGET_HOST}" in
+case "${CROSS_HOST}" in
 *"mingw"*)
   TARGET_HOST=Windows
   apt install -y wine
@@ -103,16 +104,23 @@ case "${TARGET_HOST}" in
   ;;
 *)
   TARGET_HOST=Linux
-  apt install -y "qemu-user-static"
-  if [ x"${TARGET_ARCH}" = xi686 ]; then
-    RUNNER_CHECKER="qemu-i386-static"
-  else
-    RUNNER_CHECKER="qemu-${TARGET_ARCH}-static"
-  fi
+  apt install -y "qemu-user" --no-install-recommends --no-install-suggests
+  case "${TARGET_ARCH}" in
+  i686)
+    RUNNER_CHECKER="qemu-i386"
+    ;;
+  arm*)
+    RUNNER_CHECKER="qemu-arm"
+    ;;
+  *)
+    RUNNER_CHECKER="qemu-${TARGET_ARCH}"
+    ;;
+  esac
   ;;
 esac
 
 export PKG_CONFIG_PATH="${CROSS_PREFIX}/opt/qt/lib/pkgconfig:${CROSS_PREFIX}/lib/pkgconfig:${CROSS_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
+
 SELF_DIR="$(dirname "$(readlink -f "${0}")")"
 
 mkdir -p "/usr/src"
@@ -146,8 +154,8 @@ prepare_cmake() {
     cmake_binary_url="https://github.com/Kitware/CMake/releases/download/v${cmake_latest_ver}/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz"
     cmake_sha256_url="https://github.com/Kitware/CMake/releases/download/v${cmake_latest_ver}/cmake-${cmake_latest_ver}-SHA-256.txt"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      cmake_binary_url="https://ghp.ci/${cmake_binary_url}"
-      cmake_sha256_url="https://ghp.ci/${cmake_sha256_url}"
+      cmake_binary_url="https://gh-proxy.com/${cmake_binary_url}"
+      cmake_sha256_url="https://gh-proxy.com/${cmake_sha256_url}"
     fi
     if [ -f "/usr/src/cmake-${cmake_latest_ver}-linux-x86_64.tar.gz" ]; then
       cd /usr/src
@@ -168,7 +176,7 @@ prepare_ninja() {
     ninja_ver="$(retry curl -ksSL --compressed https://ninja-build.org/ \| grep "'The last Ninja release is'" \| sed -r "'s@.*<b>(.+)</b>.*@\1@'" \| head -1)"
     ninja_binary_url="https://github.com/ninja-build/ninja/releases/download/${ninja_ver}/ninja-linux.zip"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      ninja_binary_url="https://ghp.ci/${ninja_binary_url}"
+      ninja_binary_url="https://gh-proxy.com/${ninja_binary_url}"
     fi
     if [ ! -f "/usr/src/ninja-${ninja_ver}-linux.zip.download_ok" ]; then
       rm -f "/usr/src/ninja-${ninja_ver}-linux.zip"
@@ -186,7 +194,7 @@ prepare_zlib() {
     zlib_ng_latest_url="https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${zlib_ng_latest_tag}.tar.gz"
     echo "zlib-ng version ${zlib_ng_latest_tag}"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      zlib_ng_latest_url="https://ghp.ci/${zlib_ng_latest_url}"
+      zlib_ng_latest_url="https://gh-proxy.com/${zlib_ng_latest_url}"
     fi
     if [ ! -f "/usr/src/zlib-ng-${zlib_ng_latest_tag}/.unpack_ok" ]; then
       mkdir -p "/usr/src/zlib-ng-${zlib_ng_latest_tag}/"
@@ -201,9 +209,10 @@ prepare_zlib() {
       -DZLIB_COMPAT=ON \
       -DCMAKE_SYSTEM_NAME="${TARGET_HOST}" \
       -DCMAKE_INSTALL_PREFIX="${CROSS_PREFIX}" \
-      -DCMAKE_C_COMPILER="${CROSS_HOST}-gcc" \
-      -DCMAKE_CXX_COMPILER="${CROSS_HOST}-g++" \
+      -DCMAKE_C_COMPILER="${CROSS_HOST}-cc" \
+      -DCMAKE_CXX_COMPILER="${CROSS_HOST}-c++" \
       -DCMAKE_SYSTEM_PROCESSOR="${TARGET_ARCH}" \
+      -DCMAKE_C_FLAGS="-fPIC" \
       -DWITH_GTEST=OFF
     cmake --build build
     cmake --install build
@@ -223,7 +232,7 @@ prepare_zlib() {
     if [ x"${TARGET_HOST}" = x"Windows" ]; then
       make -f win32/Makefile.gcc BINARY_PATH="${CROSS_PREFIX}/bin" INCLUDE_PATH="${CROSS_PREFIX}/include" LIBRARY_PATH="${CROSS_PREFIX}/lib" SHARED_MODE=0 PREFIX="${CROSS_HOST}-" -j$(nproc) install
     else
-      CHOST="${CROSS_HOST}" ./configure --prefix="${CROSS_PREFIX}" --static
+      CHOST="${CROSS_HOST}" CFLAGS="-fPIC" ./configure --prefix="${CROSS_PREFIX}" --static
       make -j$(nproc)
       make install
     fi
@@ -237,14 +246,14 @@ prepare_ssl() {
   if [ ! -f "/usr/src/openssl-${openssl_ver}/.unpack_ok" ]; then
     openssl_download_url="https://github.com/openssl/openssl/releases/download/openssl-${openssl_ver}/${openssl_filename}"
     if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-      openssl_download_url="https://ghp.ci/${openssl_download_url}"
+      openssl_download_url="https://gh-proxy.com/${openssl_download_url}"
     fi
     mkdir -p "/usr/src/openssl-${openssl_ver}/"
     retry curl -kL "${openssl_download_url}" \| tar -zxf - --strip-components=1 -C "/usr/src/openssl-${openssl_ver}/"
     touch "/usr/src/openssl-${openssl_ver}/.unpack_ok"
   fi
   cd "/usr/src/openssl-${openssl_ver}/"
-  ./Configure -static no-tests --openssldir=/etc/ssl --cross-compile-prefix="${CROSS_HOST}-" --prefix="${CROSS_PREFIX}" "${OPENSSL_COMPILER}"
+  CC=cc ./Configure -static no-tests -fPIC --openssldir=/etc/ssl --cross-compile-prefix="${CROSS_HOST}-" --prefix="${CROSS_PREFIX}" "${OPENSSL_COMPILER}"
   make -j$(nproc)
   make install_sw
   if [ -f "${CROSS_PREFIX}/lib64/libssl.a" ]; then
@@ -256,7 +265,8 @@ prepare_ssl() {
 }
 
 prepare_boost() {
-  # boost_ver="$(retry curl -ksSL --compressed https://www.boost.org/users/download/ \| grep "'>Version\s*'" \| sed -r "'s/.*Version\s*([^<]+).*/\1/'" \| head -1)"
+  # Boost >= 1.69: boost::system is header-only.
+  # libtorrent only links Boost::headers (see CMakeLists.txt).
   boost_ver="1.86.0"
   echo "Boost version ${boost_ver}"
   if [ ! -f "/usr/src/boost-${boost_ver}/.unpack_ok" ]; then
@@ -265,30 +275,33 @@ prepare_boost() {
     retry curl -kL "${boost_latest_url}" \| tar -jxf - -C "/usr/src/boost-${boost_ver}/" --strip-components 1
     touch "/usr/src/boost-${boost_ver}/.unpack_ok"
   fi
-  cd "/usr/src/boost-${boost_ver}/"
-  echo "using gcc : cross : ${CROSS_HOST}-g++ ;" >~/user-config.jam
-  if [ ! -f ./b2 ]; then
-    ./bootstrap.sh
-  fi
-  ./b2 -d0 -q install --prefix="${CROSS_PREFIX}" --with-system toolset=gcc-cross variant=release link=static runtime-link=static
-  cd "/usr/src/boost-${boost_ver}/tools/build"
-  if [ ! -f ./b2 ]; then
-    ./bootstrap.sh
-  fi
-  ./b2 -d0 -q install --prefix="${CROSS_ROOT}"
+  cp -rf "/usr/src/boost-${boost_ver}/boost" "${CROSS_PREFIX}/include/"
 }
 
 prepare_qt() {
-  qt_major_ver="$(retry curl -ksSL --compressed https://download.qt.io/official_releases/qt/ \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
-  qt_ver="$(retry curl -ksSL --compressed https://download.qt.io/official_releases/qt/${qt_major_ver}/ \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
+  QT_DOWNLOAD_URL_BASE="https://download.qt.io"
+  if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
+    QT_DOWNLOAD_URL_BASE="https://mirrors.sjtug.sjtu.edu.cn/qt"
+  fi
+  qt_major_ver="$(retry curl -ksSL --compressed "https://download.qt.io/official_releases/qt/" \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
+  qt_ver="$(retry curl -ksSL --compressed "https://download.qt.io/official_releases/qt/${qt_major_ver}/" \| sed -nr "'s@.*href=\"([0-9]+(\.[0-9]+)*)/\".*@\1@p'" \| grep \"^${QT_VER_PREFIX}\" \| head -1)"
   echo "Using qt version: ${qt_ver}"
   mkdir -p "/usr/src/qtbase-${qt_ver}" "/usr/src/qttools-${qt_ver}"
   if [ ! -f "/usr/src/qt-host/${qt_ver}/gcc_64/bin/qt.conf" ]; then
     pipx install aqtinstall
-    retry "${HOME}/.local/bin/aqt" install-qt -O /usr/src/qt-host linux desktop "${qt_ver}" --archives qtbase qttools icu
+    qt_archives=(qtbase qttools icu)
+    if verlte "6.11.0" "${qt_ver}"; then
+      qt_archives+=(qtdeclarative)
+    fi
+    aqt_base_args=(-O /usr/src/qt-host)
+    if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
+      aqt_base_args+=(-b "${QT_DOWNLOAD_URL_BASE}")
+    fi
+    aqt_base_args+=(linux desktop "${qt_ver}" --archives "${qt_archives[@]}")
+    retry "${HOME}/.local/bin/aqt" install-qt "${aqt_base_args[@]}"
   fi
   if [ ! -f "/usr/src/qtbase-${qt_ver}/.unpack_ok" ]; then
-    qtbase_url="https://download.qt.io/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtbase-everywhere-src-${qt_ver}.tar.xz"
+    qtbase_url="${QT_DOWNLOAD_URL_BASE}/official_releases/qt/${qt_major_ver}/${qt_ver}/submodules/qtbase-everywhere-src-${qt_ver}.tar.xz"
     retry curl -kL "${qtbase_url}" \| tar Jxf - -C "/usr/src/qtbase-${qt_ver}" --strip-components 1
     touch "/usr/src/qtbase-${qt_ver}/.unpack_ok"
   fi
@@ -320,9 +333,10 @@ prepare_qt() {
     -- \
     -DCMAKE_SYSTEM_NAME="${TARGET_HOST}" \
     -DCMAKE_SYSTEM_PROCESSOR="${TARGET_ARCH}" \
-    -DCMAKE_C_COMPILER="${CROSS_HOST}-gcc" \
-    -DCMAKE_SYSROOT="${CROSS_PREFIX}" \
-    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-g++"
+    -DCMAKE_C_COMPILER="${CROSS_HOST}-cc" \
+    -DCMAKE_PREFIX_PATH="${CROSS_PREFIX}" \
+    -DOPENSSL_ROOT_DIR="${CROSS_PREFIX}" \
+    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-c++"
   echo "========================================================"
   echo "Qt configuration:"
   cat config.summary
@@ -337,7 +351,7 @@ prepare_libtorrent() {
   echo "libtorrent-rasterbar branch: ${LIBTORRENT_BRANCH}"
   libtorrent_git_url="https://github.com/arvidn/libtorrent.git"
   if [ x"${USE_CHINA_MIRROR}" = x1 ]; then
-    libtorrent_git_url="https://ghp.ci/${libtorrent_git_url}"
+    libtorrent_git_url="https://gh-proxy.com/${libtorrent_git_url}"
   fi
   if [ ! -d "/usr/src/libtorrent-rasterbar-${LIBTORRENT_BRANCH}/" ]; then
     retry git clone --depth 1 --recursive --shallow-submodules --branch "${LIBTORRENT_BRANCH}" \
@@ -379,9 +393,9 @@ prepare_libtorrent() {
     -DBUILD_SHARED_LIBS=off \
     -DCMAKE_SYSTEM_NAME="${TARGET_HOST}" \
     -DCMAKE_SYSTEM_PROCESSOR="${TARGET_ARCH}" \
-    -DCMAKE_SYSROOT="${CROSS_PREFIX}" \
-    -DCMAKE_C_COMPILER="${CROSS_HOST}-gcc" \
-    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-g++"
+    -DCMAKE_PREFIX_PATH="${CROSS_PREFIX}" \
+    -DCMAKE_C_COMPILER="${CROSS_HOST}-cc" \
+    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-c++"
   cmake --build build
   cmake --install build
 }
@@ -402,9 +416,8 @@ build_qbittorrent() {
     -DCMAKE_CXX_STANDARD="17" \
     -DCMAKE_SYSTEM_NAME="${TARGET_HOST}" \
     -DCMAKE_SYSTEM_PROCESSOR="${TARGET_ARCH}" \
-    -DCMAKE_SYSROOT="${CROSS_PREFIX}" \
-    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-g++" \
-    -DCMAKE_EXE_LINKER_FLAGS="-static"
+    -DCMAKE_CXX_COMPILER="${CROSS_HOST}-c++" \
+    -DCMAKE_EXE_LINKER_FLAGS="-static -s"
   cmake --build build
   cmake --install build
   if [ x"${TARGET_HOST}" = x"Windows" ]; then
@@ -427,4 +440,4 @@ build_qbittorrent
 "${RUNNER_CHECKER}" /tmp/qbittorrent-nox* --version 2>/dev/null
 
 # archive qbittorrent
-zip -j9v "${SELF_DIR}/qbittorrent-enhanced-nox_${CROSS_HOST}_static.zip" /tmp/qbittorrent-nox*
+zip -j9v "${SELF_DIR}/qbittorrent-enhanced-nox_${CROSS_HOST//-unknown/}_static.zip" /tmp/qbittorrent-nox*


### PR DESCRIPTION
Still use libtorrent 1.2 + boost 1.86.0, because qbittorrent official use it by default release.

## AppImage

- upgrade base image to ubuntu 22.04 since qbittorrent required high `libstdc++` version
- add aarch64 AppImage

## cross build

- remove `arm` and add `armv7`, because qt 6.11.0 dropped support **VERY OLD ARM Architecture**
- remove mips 32 bit since qt 6.11.0 cannot build success. And I've submitted a bug report to qt: [QTBUG-146670](https://qt-project.atlassian.net/browse/QTBUG-146670)