### PR TITLE
WebUI: fix Shadow Ban toggle save/read field name mismatch

### DIFF
--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -792,6 +792,8 @@ void AppController::setPreferencesAction()
         session->setAutoBanBTPlayerPeer(it.value().toBool());
     if (hasKey(u"shadow_ban"_s))
         session->setShadowBan(it.value().toBool());
+    else if (hasKey(u"shadow_ban_enabled"_s))
+        session->setShadowBan(it.value().toBool());
     if (hasKey(u"shadow_banned_IPs"_s))
         session->setShadowBannedIPs(it.value().toString().split(u'\n', Qt::SkipEmptyParts));
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2729,9 +2729,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("ignoreSSLErrors").checked = pref.ignore_ssl_errors;
                     document.getElementById("pythonExecutablePath").value = pref.python_executable_path;
                     document.getElementById("autoBanUnknownPeer").checked = pref.auto_ban_unknown_peer;
-                    document.getElementById("autoBanBittorrentPlayer").checked = pref.auto_ban_unknown_peer;
-                    document.getElementById("shadowBan").checked = pref.auto_ban_unknown_peer;
-                    document.getElementById("shadowBannedIPs").value = pref.auto_ban_unknown_peer;
+                    document.getElementById("autoBanBittorrentPlayer").checked = pref.auto_ban_bt_player_peer;
+                    document.getElementById("shadowBan").checked = pref.shadow_ban_enabled;
+                    document.getElementById("shadowBannedIPs").value = pref.shadow_banned_IPs;
                     // libtorrent section
                     document.getElementById("bdecodeDepthLimit").value = pref.bdecode_depth_limit;
                     document.getElementById("bdecodeTokenLimit").value = pref.bdecode_token_limit;
@@ -3222,7 +3222,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["python_executable_path"] = document.getElementById("pythonExecutablePath").value;
             settings["auto_ban_unknown_peer"] = document.getElementById("autoBanUnknownPeer").checked;
             settings["auto_ban_bt_player_peer"] = document.getElementById("autoBanBittorrentPlayer").checked;
-            settings["shadow_ban_enabled"] = document.getElementById("shadowBan").checked;
+            settings["shadow_ban"] = document.getElementById("shadowBan").checked;
             settings["shadow_banned_IPs"] = document.getElementById("shadowBannedIPs").value;
 
             // libtorrent section


### PR DESCRIPTION
Fixes #718

## Problem

The Shadow Ban toggle in the WebUI preferences page never works: after enabling it and saving, reopening the page always shows it OFF and the setting is never persisted. Two field-name bugs in the WebUI frontend cause this:

**Bug 1 - save is silently dropped.** The frontend submits `shadow_ban_enabled`, but the backend `setPreferencesAction()` only recognizes `shadow_ban`, so the value is ignored:
- `src/webui/www/private/views/preferences.html`: `settings["shadow_ban_enabled"] = ...`
- `src/webui/api/appcontroller.cpp`: `if (hasKey(u"shadow_ban"_s))`

**Bug 2 - wrong field used for read-back.** The toggle and the IP list are populated from the unrelated `auto_ban_unknown_peer` instead of the values the backend actually returns (`shadow_ban_enabled` / `shadow_banned_IPs`):

```js
document.getElementById("shadowBan").checked = pref.auto_ban_unknown_peer;     // wrong
document.getElementById("shadowBannedIPs").value = pref.auto_ban_unknown_peer; // wrong
```

The same read-back bug affects the "Auto Ban Bittorrent Media Player" toggle (reads `auto_ban_unknown_peer` instead of `auto_ban_bt_player_peer`).

## Changes

- `preferences.html`: read-back now uses `pref.auto_ban_bt_player_peer`, `pref.shadow_ban_enabled`, `pref.shadow_banned_IPs`
- `preferences.html`: save now submits `shadow_ban` (the key the backend expects)
- `appcontroller.cpp`: also accept `shadow_ban_enabled` in `setPreferencesAction()` for backward compatibility with any client still sending the old key

## Verification

- Backend `GET /api/v2/app/preferences` already returns `shadow_ban_enabled` and `shadow_banned_IPs`, and setting `{"shadow_ban": true}` via `POST /api/v2/app/setPreferences` works - so only the frontend keys were wrong.
- After the fix: saving the toggle persists `Session\ShadowBan=true` under `[BitTorrent]`, and reopening the preferences page shows the correct state (note: the ShadowBan plugin is only mounted at program startup, so a restart is still required for the ban behavior itself to take effect).
- The per-peer right-click "manual Shadow Ban" menu uses matching keys and was already working.